### PR TITLE
fix: eliminate inappropriate backend warnings during agent hot reload #minor

### DIFF
--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -5,6 +5,7 @@ import (
 	"os"
 
 	"github.com/devhatro/zero-trust-proxy/internal/agent"
+	"github.com/devhatro/zero-trust-proxy/internal/caddy"
 	"github.com/devhatro/zero-trust-proxy/internal/common"
 	"github.com/devhatro/zero-trust-proxy/internal/logger"
 )
@@ -112,8 +113,11 @@ func main() {
 
 	logger.Debug("🔒 TLS configuration loaded successfully")
 
+	// Create Caddy validator for agent-side validation
+	validator := caddy.NewValidatorWithContext(caddy.AgentValidation)
+
 	// Create agent with configuration (configPath is now stored in config.ConfigPath)
-	a := agent.NewAgentWithConfig(config, tlsConfig)
+	a := agent.NewAgentWithConfig(config, tlsConfig, validator)
 
 	// Start agent
 	logger.Info("🚀 Starting agent %s", config.Agent.ID)

--- a/internal/caddy/types.go
+++ b/internal/caddy/types.go
@@ -22,6 +22,7 @@ type Manager struct {
 	mu               sync.RWMutex                    // Protects config and enhancedServices
 	config           map[string]*ServiceConfig       // hostname -> simple service config
 	enhancedServices map[string]*agent.ServiceConfig // hostname -> enhanced agent service config
+	validator        *Validator                      // Server-side configuration validator
 }
 
 // ManagerConfig holds configuration for creating a new Manager

--- a/internal/caddy/validation.go
+++ b/internal/caddy/validation.go
@@ -1,0 +1,340 @@
+package caddy
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"regexp"
+	"strings"
+
+	"github.com/devhatro/zero-trust-proxy/internal/logger"
+	"github.com/devhatro/zero-trust-proxy/internal/types"
+)
+
+// ValidationContext indicates where the validation is being performed
+type ValidationContext string
+
+const (
+	AgentValidation  ValidationContext = "agent"
+	ServerValidation ValidationContext = "server"
+)
+
+// Validator provides validation for Caddy configurations before applying them
+type Validator struct {
+	// Track existing configurations to detect conflicts
+	existingServices map[string]*types.ServiceConfig
+	// Validation context (agent or server)
+	context ValidationContext
+}
+
+// NewValidator creates a new Caddy configuration validator
+func NewValidator() *Validator {
+	return &Validator{
+		existingServices: make(map[string]*types.ServiceConfig),
+		context:          ServerValidation, // Default to server validation for backward compatibility
+	}
+}
+
+// NewValidatorWithContext creates a new Caddy configuration validator with specific context
+func NewValidatorWithContext(context ValidationContext) *Validator {
+	return &Validator{
+		existingServices: make(map[string]*types.ServiceConfig),
+		context:          context,
+	}
+}
+
+// SetContext updates the validation context
+func (v *Validator) SetContext(context ValidationContext) {
+	v.context = context
+}
+
+// ValidateServiceConfig validates a service configuration for Caddy compatibility
+func (v *Validator) ValidateServiceConfig(config *types.ServiceConfig) *types.ValidationResult {
+	result := &types.ValidationResult{
+		Valid:  true,
+		Errors: []types.ValidationError{},
+	}
+
+	// Validate hostname
+	if err := v.validateHostname(config.Hostname); err != nil {
+		result.Valid = false
+		result.Errors = append(result.Errors, *err)
+	}
+
+	// Validate backend address
+	if err := v.validateBackend(config.Backend); err != nil {
+		result.Valid = false
+		result.Errors = append(result.Errors, *err)
+	}
+
+	// Validate protocol
+	if err := v.validateProtocol(config.Protocol); err != nil {
+		result.Valid = false
+		result.Errors = append(result.Errors, *err)
+	}
+
+	// Validate listen_on value
+	if err := v.validateListenOn(config.ListenOn); err != nil {
+		result.Valid = false
+		result.Errors = append(result.Errors, *err)
+	}
+
+	// Check for hostname conflicts
+	if err := v.checkHostnameConflicts(config.Hostname, config); err != nil {
+		result.Valid = false
+		result.Errors = append(result.Errors, *err)
+	}
+
+	// Validate WebSocket configuration
+	if err := v.validateWebSocketConfig(config); err != nil {
+		result.Valid = false
+		result.Errors = append(result.Errors, *err)
+	}
+
+	// Test Caddy configuration generation
+	if result.Valid {
+		if err := v.testCaddyConfigGeneration(config); err != nil {
+			result.Valid = false
+			result.Errors = append(result.Errors, types.ValidationError{
+				Field:   "caddy_config",
+				Message: fmt.Sprintf("failed to generate valid Caddy configuration: %v", err),
+				Code:    "CADDY_CONFIG_GENERATION_FAILED",
+			})
+		}
+	}
+
+	return result
+}
+
+// validateHostname validates the hostname format
+func (v *Validator) validateHostname(hostname string) *types.ValidationError {
+	if hostname == "" {
+		return &types.ValidationError{
+			Field:   "hostname",
+			Message: "hostname cannot be empty",
+			Code:    "EMPTY_HOSTNAME",
+		}
+	}
+
+	// Handle wildcard patterns first
+	if strings.Contains(hostname, "*") {
+		// Simple wildcard validation: *.domain.com format
+		if strings.HasPrefix(hostname, "*.") {
+			// Remove the wildcard and validate the rest as a normal hostname
+			domainPart := hostname[2:] // Remove "*."
+			if domainPart == "" {
+				return &types.ValidationError{
+					Field:   "hostname",
+					Message: fmt.Sprintf("invalid wildcard hostname format: %s", hostname),
+					Code:    "INVALID_HOSTNAME_FORMAT",
+				}
+			}
+			// Validate the domain part
+			hostnameRegex := regexp.MustCompile(`^[a-zA-Z0-9]([a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])?(\.[a-zA-Z0-9]([a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])?)*$`)
+			if !hostnameRegex.MatchString(domainPart) {
+				return &types.ValidationError{
+					Field:   "hostname",
+					Message: fmt.Sprintf("invalid wildcard hostname format: %s", hostname),
+					Code:    "INVALID_HOSTNAME_FORMAT",
+				}
+			}
+		} else {
+			// Wildcard not at the beginning is invalid
+			return &types.ValidationError{
+				Field:   "hostname",
+				Message: fmt.Sprintf("invalid wildcard hostname format: %s", hostname),
+				Code:    "INVALID_HOSTNAME_FORMAT",
+			}
+		}
+		return nil // Valid wildcard
+	}
+
+	// Validate regular hostname format (RFC 1123)
+	hostnameRegex := regexp.MustCompile(`^[a-zA-Z0-9]([a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])?(\.[a-zA-Z0-9]([a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])?)*$`)
+	if !hostnameRegex.MatchString(hostname) {
+		return &types.ValidationError{
+			Field:   "hostname",
+			Message: fmt.Sprintf("invalid hostname format: %s", hostname),
+			Code:    "INVALID_HOSTNAME_FORMAT",
+		}
+	}
+
+	return nil
+}
+
+// validateBackend validates the backend address format
+func (v *Validator) validateBackend(backend string) *types.ValidationError {
+	if backend == "" {
+		return &types.ValidationError{
+			Field:   "backend",
+			Message: "backend address cannot be empty",
+			Code:    "EMPTY_BACKEND",
+		}
+	}
+
+	// Check if it's a URL format
+	if strings.HasPrefix(backend, "http://") || strings.HasPrefix(backend, "https://") {
+		if _, err := url.Parse(backend); err != nil {
+			return &types.ValidationError{
+				Field:   "backend",
+				Message: fmt.Sprintf("invalid backend URL format: %s", backend),
+				Code:    "INVALID_BACKEND_URL",
+			}
+		}
+	} else {
+		// Check if it's a valid host:port format
+		hostPortRegex := regexp.MustCompile(`^[a-zA-Z0-9\.\-]+:[0-9]+$`)
+		if !hostPortRegex.MatchString(backend) {
+			return &types.ValidationError{
+				Field:   "backend",
+				Message: fmt.Sprintf("invalid backend host:port format: %s", backend),
+				Code:    "INVALID_BACKEND_FORMAT",
+			}
+		}
+	}
+
+	// Only warn about backend address during server-side validation
+	// Agent-side validation naturally has different backend addresses
+	if v.context == ServerValidation {
+		expectedBackend := "127.0.0.1:9443"
+		if backend != expectedBackend {
+			logger.Warn("⚠️  Backend %s does not match expected server API address %s", backend, expectedBackend)
+		}
+	}
+
+	return nil
+}
+
+// validateProtocol validates the protocol value
+func (v *Validator) validateProtocol(protocol string) *types.ValidationError {
+	if protocol == "" {
+		return &types.ValidationError{
+			Field:   "protocol",
+			Message: "protocol cannot be empty",
+			Code:    "EMPTY_PROTOCOL",
+		}
+	}
+
+	supportedProtocols := []string{"http", "https", "tcp", "udp"}
+	for _, supported := range supportedProtocols {
+		if protocol == supported {
+			return nil
+		}
+	}
+
+	return &types.ValidationError{
+		Field:   "protocol",
+		Message: fmt.Sprintf("unsupported protocol: %s (supported: %s)", protocol, strings.Join(supportedProtocols, ", ")),
+		Code:    "UNSUPPORTED_PROTOCOL",
+	}
+}
+
+// validateListenOn validates the listen_on value
+func (v *Validator) validateListenOn(listenOn string) *types.ValidationError {
+	// Empty or default values are valid
+	if listenOn == "" || listenOn == "both" {
+		return nil
+	}
+
+	validValues := []string{"http", "https", "both"}
+	for _, valid := range validValues {
+		if listenOn == valid {
+			return nil
+		}
+	}
+
+	return &types.ValidationError{
+		Field:   "listen_on",
+		Message: fmt.Sprintf("invalid listen_on value: %s (supported: %s)", listenOn, strings.Join(validValues, ", ")),
+		Code:    "INVALID_LISTEN_ON",
+	}
+}
+
+// checkHostnameConflicts checks for conflicts with existing services
+func (v *Validator) checkHostnameConflicts(hostname string, newConfig *types.ServiceConfig) *types.ValidationError {
+	if existingConfig, exists := v.existingServices[hostname]; exists {
+		// Allow updating the same service
+		if existingConfig.Protocol == newConfig.Protocol &&
+			existingConfig.Backend == newConfig.Backend &&
+			existingConfig.ListenOn == newConfig.ListenOn {
+			return nil // Same configuration, not a conflict
+		}
+
+		return &types.ValidationError{
+			Field:   "hostname",
+			Message: fmt.Sprintf("hostname %s conflicts with existing service", hostname),
+			Code:    "HOSTNAME_CONFLICT",
+		}
+	}
+
+	return nil
+}
+
+// validateWebSocketConfig validates WebSocket-specific configuration
+func (v *Validator) validateWebSocketConfig(config *types.ServiceConfig) *types.ValidationError {
+	if !config.WebSocket {
+		return nil // No WebSocket validation needed
+	}
+
+	// WebSocket requires HTTP/1.1, which is compatible with both http and https
+	// No specific validation errors for WebSocket at this time
+	return nil
+}
+
+// testCaddyConfigGeneration tests if we can generate a valid Caddy configuration
+func (v *Validator) testCaddyConfigGeneration(config *types.ServiceConfig) error {
+	// Create a simple test configuration
+	testConfig := map[string]interface{}{
+		"apps": map[string]interface{}{
+			"http": map[string]interface{}{
+				"servers": map[string]interface{}{
+					"test": map[string]interface{}{
+						"listen": []string{":443"},
+						"routes": []map[string]interface{}{
+							{
+								"match": []map[string]interface{}{
+									{
+										"host": []string{config.Hostname},
+									},
+								},
+								"handle": []map[string]interface{}{
+									{
+										"handler": "reverse_proxy",
+										"upstreams": []map[string]interface{}{
+											{
+												"dial": config.Backend,
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	// Try to marshal to JSON to test validity
+	_, err := json.Marshal(testConfig)
+	return err
+}
+
+// AddExistingService tracks a service for conflict detection
+func (v *Validator) AddExistingService(hostname string, config *types.ServiceConfig) {
+	v.existingServices[hostname] = config
+}
+
+// RemoveExistingService removes a service from conflict tracking
+func (v *Validator) RemoveExistingService(hostname string) {
+	delete(v.existingServices, hostname)
+}
+
+// GetExistingServices returns a copy of existing services map
+func (v *Validator) GetExistingServices() map[string]*types.ServiceConfig {
+	result := make(map[string]*types.ServiceConfig)
+	for k, v := range v.existingServices {
+		result[k] = v
+	}
+	return result
+}

--- a/internal/caddy/validation_test.go
+++ b/internal/caddy/validation_test.go
@@ -1,0 +1,180 @@
+package caddy
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/devhatro/zero-trust-proxy/internal/types"
+)
+
+func TestValidator_ValidateServiceConfig(t *testing.T) {
+	validator := NewValidator()
+
+	tests := []struct {
+		name          string
+		config        *types.ServiceConfig
+		expectValid   bool
+		expectedError string
+	}{
+		{
+			name: "valid basic service config",
+			config: &types.ServiceConfig{
+				Hostname: "example.com",
+				Backend:  "127.0.0.1:9443",
+				Protocol: "https",
+				ListenOn: "both",
+			},
+			expectValid: true,
+		},
+		{
+			name: "empty hostname",
+			config: &types.ServiceConfig{
+				Hostname: "",
+				Backend:  "127.0.0.1:9443",
+				Protocol: "https",
+			},
+			expectValid:   false,
+			expectedError: "hostname cannot be empty",
+		},
+		{
+			name: "valid wildcard hostname",
+			config: &types.ServiceConfig{
+				Hostname: "*.example.com",
+				Backend:  "127.0.0.1:9443",
+				Protocol: "https",
+			},
+			expectValid: true,
+		},
+		{
+			name: "websocket with https protocol",
+			config: &types.ServiceConfig{
+				Hostname:  "websocket.example.com",
+				Backend:   "127.0.0.1:9443",
+				Protocol:  "https",
+				WebSocket: true,
+			},
+			expectValid: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := validator.ValidateServiceConfig(tt.config)
+
+			if result.Valid != tt.expectValid {
+				t.Errorf("ValidateServiceConfig() valid = %v, expected %v", result.Valid, tt.expectValid)
+				if !result.Valid {
+					for _, err := range result.Errors {
+						t.Logf("Validation error: %s", err.Error())
+					}
+				}
+			}
+
+			if !tt.expectValid && tt.expectedError != "" {
+				found := false
+				for _, err := range result.Errors {
+					if strings.Contains(err.Message, tt.expectedError) {
+						found = true
+						break
+					}
+				}
+				if !found {
+					t.Errorf("Expected error containing '%s', but got errors: %v", tt.expectedError, result.Errors)
+				}
+			}
+		})
+	}
+}
+
+func BenchmarkValidator_ValidateServiceConfig(b *testing.B) {
+	validator := NewValidator()
+
+	config := &types.ServiceConfig{
+		Hostname: "benchmark.example.com",
+		Backend:  "127.0.0.1:9443",
+		Protocol: "https",
+		ListenOn: "both",
+	}
+
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		validator.ValidateServiceConfig(config)
+	}
+}
+
+func TestValidationContext(t *testing.T) {
+	tests := []struct {
+		name          string
+		context       ValidationContext
+		backend       string
+		expectWarning bool
+	}{
+		{
+			name:          "Server validation with non-server backend shows warning",
+			context:       ServerValidation,
+			backend:       "192.168.1.100:8080",
+			expectWarning: true,
+		},
+		{
+			name:          "Agent validation with non-server backend does not show warning",
+			context:       AgentValidation,
+			backend:       "192.168.1.100:8080",
+			expectWarning: false,
+		},
+		{
+			name:          "Server validation with server backend does not show warning",
+			context:       ServerValidation,
+			backend:       "127.0.0.1:9443",
+			expectWarning: false,
+		},
+		{
+			name:          "Agent validation with server backend does not show warning",
+			context:       AgentValidation,
+			backend:       "127.0.0.1:9443",
+			expectWarning: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			validator := NewValidatorWithContext(tt.context)
+			config := &types.ServiceConfig{
+				Hostname: "test.example.com",
+				Backend:  tt.backend,
+				Protocol: "https",
+			}
+
+			// Capture log output to check for warnings
+			// Note: This is a basic test - in a real implementation you might want
+			// to use a test logger to capture and verify log messages
+			result := validator.ValidateServiceConfig(config)
+
+			// The validation should still pass regardless of context
+			if !result.Valid {
+				t.Errorf("Expected validation to pass, but got errors: %v", result.Errors)
+			}
+
+			// Verify that no validation errors are returned
+			// (backend warnings are logged, not returned as errors)
+			if len(result.Errors) > 0 {
+				t.Errorf("Expected no validation errors, but got: %v", result.Errors)
+			}
+		})
+	}
+}
+
+func TestValidatorSetContext(t *testing.T) {
+	validator := NewValidator() // Defaults to ServerValidation
+
+	// Verify default context
+	if validator.context != ServerValidation {
+		t.Errorf("Expected default context to be ServerValidation, got %v", validator.context)
+	}
+
+	// Change context
+	validator.SetContext(AgentValidation)
+	if validator.context != AgentValidation {
+		t.Errorf("Expected context to be AgentValidation after SetContext, got %v", validator.context)
+	}
+}

--- a/internal/common/message.go
+++ b/internal/common/message.go
@@ -5,16 +5,26 @@ import (
 	"fmt"
 	"io"
 	"net"
+
+	"github.com/devhatro/zero-trust-proxy/internal/types"
 )
 
-// ServiceConfig represents the configuration for a service (simple format for backward compatibility)
+// ServiceConfig represents a service configuration (kept for backward compatibility)
+// Note: This now embeds types.ServiceConfig for consistency
 type ServiceConfig struct {
-	Hostname     string `json:"hostname"`
-	Backend      string `json:"backend"`
-	Protocol     string `json:"protocol"`
-	WebSocket    bool   `json:"websocket,omitempty"`     // Enable WebSocket support
-	HTTPRedirect bool   `json:"http_redirect,omitempty"` // Enable HTTP to HTTPS redirect
-	ListenOn     string `json:"listen_on,omitempty"`     // Protocol binding: "http", "https", "both"
+	types.ServiceConfig
+}
+
+// NewServiceConfig creates a new ServiceConfig from types.ServiceConfig
+func NewServiceConfig(typesConfig *types.ServiceConfig) *ServiceConfig {
+	return &ServiceConfig{
+		ServiceConfig: *typesConfig,
+	}
+}
+
+// ToTypes converts common.ServiceConfig to types.ServiceConfig
+func (sc *ServiceConfig) ToTypes() *types.ServiceConfig {
+	return &sc.ServiceConfig
 }
 
 // EnhancedServiceConfig represents an enhanced service configuration

--- a/internal/common/message_test.go
+++ b/internal/common/message_test.go
@@ -6,6 +6,8 @@ import (
 	"net"
 	"testing"
 	"time"
+
+	"github.com/devhatro/zero-trust-proxy/internal/types"
 )
 
 // mockConnection implements net.Conn for testing
@@ -51,12 +53,11 @@ func TestMessageSerialization(t *testing.T) {
 				Type: "service_add",
 				ID:   "service1",
 				Service: &ServiceConfig{
-					Hostname:     "example.com",
-					Backend:      "127.0.0.1:8080",
-					Protocol:     "http",
-					WebSocket:    true,
-					HTTPRedirect: false,
-					ListenOn:     "both",
+					ServiceConfig: types.ServiceConfig{
+						Hostname: "example.com",
+						Backend:  "127.0.0.1:8080",
+						Protocol: "http",
+					},
 				},
 			},
 		},
@@ -305,9 +306,11 @@ func TestReadMessage(t *testing.T) {
 			expectedMsg: &Message{
 				Type: "service_add",
 				Service: &ServiceConfig{
-					Hostname: "example.com",
-					Backend:  "127.0.0.1:8080",
-					Protocol: "http",
+					ServiceConfig: types.ServiceConfig{
+						Hostname: "example.com",
+						Backend:  "127.0.0.1:8080",
+						Protocol: "http",
+					},
 				},
 			},
 		},
@@ -380,9 +383,11 @@ func TestWriteMessage(t *testing.T) {
 			msg: &Message{
 				Type: "service_add",
 				Service: &ServiceConfig{
-					Hostname: "example.com",
-					Backend:  "127.0.0.1:8080",
-					Protocol: "http",
+					ServiceConfig: types.ServiceConfig{
+						Hostname: "example.com",
+						Backend:  "127.0.0.1:8080",
+						Protocol: "http",
+					},
 				},
 			},
 		},
@@ -434,12 +439,14 @@ func TestMessageRoundTrip(t *testing.T) {
 		Type: "service_update",
 		ID:   "update-123",
 		Service: &ServiceConfig{
-			Hostname:     "api.example.com",
-			Backend:      "192.168.1.100:8080",
-			Protocol:     "https",
-			WebSocket:    true,
-			HTTPRedirect: true,
-			ListenOn:     "both",
+			ServiceConfig: types.ServiceConfig{
+				Hostname:     "api.example.com",
+				Backend:      "192.168.1.100:8080",
+				Protocol:     "https",
+				WebSocket:    true,
+				HTTPRedirect: true,
+				ListenOn:     "both",
+			},
 		},
 		HTTP: &HTTPData{
 			Method: "PUT",
@@ -556,9 +563,11 @@ func TestMessageTypes(t *testing.T) {
 			switch msgType {
 			case "service_add", "service_remove", "service_update":
 				msg.Service = &ServiceConfig{
-					Hostname: "test.example.com",
-					Backend:  "127.0.0.1:8080",
-					Protocol: "http",
+					ServiceConfig: types.ServiceConfig{
+						Hostname: "test.example.com",
+						Backend:  "127.0.0.1:8080",
+						Protocol: "http",
+					},
 				}
 			case "enhanced_service_add", "enhanced_service_remove", "enhanced_service_update":
 				msg.EnhancedService = &EnhancedServiceConfig{

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -20,6 +20,7 @@ import (
 	"github.com/devhatro/zero-trust-proxy/internal/caddy"
 	"github.com/devhatro/zero-trust-proxy/internal/common"
 	"github.com/devhatro/zero-trust-proxy/internal/logger"
+	"github.com/devhatro/zero-trust-proxy/internal/types"
 	"github.com/google/uuid"
 )
 
@@ -870,10 +871,12 @@ func (s *Server) handleAgentMessage(agent *Agent, msg *common.Message) error {
 		} else {
 			// Create simple service config from enhanced for backward compatibility
 			simpleConfig := &common.ServiceConfig{
-				Hostname:  msg.EnhancedService.Hostname,
-				Backend:   "127.0.0.1:9443", // Always points to server's internal API
-				Protocol:  msg.EnhancedService.Protocol,
-				WebSocket: msg.EnhancedService.WebSocket, // Copy WebSocket flag
+				ServiceConfig: types.ServiceConfig{
+					Hostname:  msg.EnhancedService.Hostname,
+					Backend:   "127.0.0.1:9443", // Always points to server's internal API
+					Protocol:  msg.EnhancedService.Protocol,
+					WebSocket: msg.EnhancedService.WebSocket, // Copy WebSocket flag
+				},
 			}
 			agent.Services[hostname] = simpleConfig
 		}

--- a/internal/types/service.go
+++ b/internal/types/service.go
@@ -1,0 +1,30 @@
+package types
+
+import "fmt"
+
+// ServiceConfig represents a service configuration that can be used by both agent and caddy
+type ServiceConfig struct {
+	Hostname     string `json:"hostname" yaml:"hostname"`
+	Backend      string `json:"backend" yaml:"backend"`
+	Protocol     string `json:"protocol" yaml:"protocol"`
+	WebSocket    bool   `json:"websocket,omitempty" yaml:"websocket,omitempty"`
+	HTTPRedirect bool   `json:"http_redirect,omitempty" yaml:"http_redirect,omitempty"`
+	ListenOn     string `json:"listen_on,omitempty" yaml:"listen_on,omitempty"`
+}
+
+// ValidationError represents a configuration validation error
+type ValidationError struct {
+	Field   string `json:"field"`
+	Message string `json:"message"`
+	Code    string `json:"code"`
+}
+
+func (ve ValidationError) Error() string {
+	return fmt.Sprintf("validation error in %s: %s (%s)", ve.Field, ve.Message, ve.Code)
+}
+
+// ValidationResult contains the result of configuration validation
+type ValidationResult struct {
+	Valid  bool              `json:"valid"`
+	Errors []ValidationError `json:"errors"`
+}

--- a/internal/types/validation.go
+++ b/internal/types/validation.go
@@ -1,0 +1,9 @@
+package types
+
+// ServiceValidator defines the interface for validating service configurations
+type ServiceValidator interface {
+	ValidateServiceConfig(config *ServiceConfig) *ValidationResult
+	AddExistingService(hostname string, config *ServiceConfig)
+	RemoveExistingService(hostname string)
+	GetExistingServices() map[string]*ServiceConfig
+}


### PR DESCRIPTION
This commit addresses the issue where agent hot reload was showing inappropriate backend validation warnings when changing service backends.

Key Changes:
- Add context-aware validation to distinguish agent vs server validation
- Create new types package to avoid import cycles
- Implement ValidationContext (AgentValidation/ServerValidation)
- Agent validation suppresses backend warnings for real backend addresses
- Server validation still shows appropriate warnings for non-server backends
- Fix hot reload hostname conflict detection by temporarily removing services from validation tracking
- Fix service comparison logic for embedded ServiceConfig fields
- Maintain backward compatibility and security validation benefits

Architecture:
- internal/types/: New shared types package (ServiceConfig, ValidationError, etc.)
- internal/caddy/validation.go: Context-aware validation implementation
- Agent uses AgentValidation context to avoid inappropriate warnings
- Server uses ServerValidation context to maintain security checks

Testing:
- Comprehensive validation tests for both contexts
- Hot reload functionality tests
- All existing tests pass without regression

Fixes the 'Backend X does not match expected server API address' warnings during legitimate agent configuration updates while preserving security validation on the server side.