### PR TITLE
feat: add on-demand TLS for automatic Let's Encrypt cert provisioning #major

### DIFF
--- a/config/Caddyfile.example
+++ b/config/Caddyfile.example
@@ -1,21 +1,35 @@
 {
 	admin localhost:2019
-	auto_https off
 
-	# Zero-trust agent control plane: listens for mTLS agent connections.
+	# on_demand_tls asks this endpoint before issuing a LE cert for any domain.
+	# The ztagents module registers this route — it returns 200 only if the
+	# domain has an active service registered via the mTLS channel.
+	on_demand_tls {
+		ask http://localhost:2019/zero-trust/check-domain
+	}
+
+	# Zero-trust agent control plane: mTLS listener using private CA certs.
+	# Separate from public HTTPS — agents connect here, not clients.
 	zerotrust_agents {
 		listen :8443
-		cert_file config/certs/server.crt
-		key_file config/certs/server.key
-		ca_file config/certs/ca.crt
+		cert_file /config/certs/server.crt
+		key_file  /config/certs/server.key
+		ca_file   /config/certs/ca.crt
 	}
 }
 
-# Ingress: every request hits the zerotrust_router, which looks up the
-# destination agent by Host header at request time. No per-service routes
-# are required — services register dynamically via the mTLS channel.
-:18080 {
-	# Catch-all route — the handler dispatches on Host internally.
+# Redirect HTTP → HTTPS (Caddy also handles ACME HTTP-01 challenges here).
+:80 {
+	redir https://{host}{uri} 308
+}
+
+# On-demand TLS: Caddy obtains a Let's Encrypt cert on first connection for
+# each domain. No domains need to be listed — the zerotrust_router dispatches
+# by Host header to whichever agent registered that service.
+:443 {
+	tls {
+		on_demand
+	}
 	route {
 		zerotrust_router {
 			request_timeout 2m

--- a/modules/ztagents/admin.go
+++ b/modules/ztagents/admin.go
@@ -1,0 +1,37 @@
+package ztagents
+
+import (
+	"net/http"
+
+	"github.com/caddyserver/caddy/v2"
+)
+
+// Routes implements caddy.AdminRouter. It registers a domain-check endpoint
+// used by Caddy's on_demand_tls to validate a domain before requesting a
+// Let's Encrypt certificate. Returns 200 if the domain has a registered
+// service, 403 otherwise.
+func (a *App) Routes() []caddy.AdminRoute {
+	return []caddy.AdminRoute{
+		{
+			Pattern: "/zero-trust/check-domain",
+			Handler: caddy.AdminHandlerFunc(a.serveCheckDomain),
+		},
+	}
+}
+
+func (a *App) serveCheckDomain(w http.ResponseWriter, r *http.Request) error {
+	domain := r.URL.Query().Get("domain")
+	if domain == "" || a.rt == nil {
+		w.WriteHeader(http.StatusBadRequest)
+		return nil
+	}
+	_, ok := a.rt.registry.lookupByHost(domain)
+	if !ok {
+		w.WriteHeader(http.StatusForbidden)
+		return nil
+	}
+	w.WriteHeader(http.StatusOK)
+	return nil
+}
+
+var _ caddy.AdminRouter = (*App)(nil)


### PR DESCRIPTION
  Register a Caddy admin route (/zero-trust/check-domain) in the ztagents
  module that gates LE cert issuance to domains with active agent services.
  Update Caddyfile.example to use on_demand TLS on :443 and HTTP redirect
  on :80 — no domains need to be listed manually in the config.