### PR TITLE
Fix/check server and chunked streaming

### DIFF
--- a/config/Caddyfile.example
+++ b/config/Caddyfile.example
@@ -18,9 +18,12 @@
 	}
 }
 
-# Redirect HTTP → HTTPS (Caddy also handles ACME HTTP-01 challenges here).
+# Redirect HTTP → HTTPS. ACME challenge paths are excluded so Let's Encrypt
+# can complete HTTP-01 challenges without being sent to a HTTPS URL that
+# doesn't have a cert yet.
 :80 {
-	redir https://{host}{uri} 308
+	@notacme not path /.well-known/acme-challenge/*
+	redir @notacme https://{host}{uri} 308
 }
 
 # On-demand TLS: Caddy obtains a Let's Encrypt cert on first connection for

--- a/internal/streaming/download.go
+++ b/internal/streaming/download.go
@@ -270,15 +270,17 @@ func (ds *DownloadStreamer) StreamToConnection(conn net.Conn, responseChan <-cha
 	}
 }
 
-// ShouldStream determines if a response should be streamed based on size
+// ShouldStream determines if a response should be streamed based on size.
+// Chunked transfers (contentLength < 0) are always streamed so unbounded
+// responses don't get fully buffered in memory. The chunking overhead for
+// small chunked JSON responses is negligible compared to the memory risk.
 func ShouldStream(contentLength int64, contentType string) bool {
-	// Always stream if content is large (>1MB) and size is known
 	if contentLength > 1024*1024 {
 		return true
 	}
-
-	// For unknown content length (-1), we'll use adaptive detection
-	// This will be handled by the adaptive buffer in the agent
+	if contentLength < 0 {
+		return true
+	}
 	return false
 }
 

--- a/modules/ztagents/admin.go
+++ b/modules/ztagents/admin.go
@@ -1,37 +1,68 @@
 package ztagents
 
 import (
+	"context"
+	"fmt"
+	"net"
 	"net/http"
-
-	"github.com/caddyserver/caddy/v2"
+	"time"
 )
 
-// Routes implements caddy.AdminRouter. It registers a domain-check endpoint
-// used by Caddy's on_demand_tls to validate a domain before requesting a
-// Let's Encrypt certificate. Returns 200 if the domain has a registered
-// service, 403 otherwise.
-func (a *App) Routes() []caddy.AdminRoute {
-	return []caddy.AdminRoute{
-		{
-			Pattern: "/zero-trust/check-domain",
-			Handler: caddy.AdminHandlerFunc(a.serveCheckDomain),
-		},
-	}
-}
+const defaultCheckAddr = "127.0.0.1:2020"
 
-func (a *App) serveCheckDomain(w http.ResponseWriter, r *http.Request) error {
-	domain := r.URL.Query().Get("domain")
-	if domain == "" || a.rt == nil {
-		w.WriteHeader(http.StatusBadRequest)
-		return nil
+// startCheckServer runs a localhost HTTP listener that answers Caddy's
+// on_demand_tls `ask` queries. Returns 200 if the requested domain has an
+// active agent-registered service, 403 otherwise. We don't use Caddy's admin
+// API here because module-provided admin routes are unreliable across Caddy
+// versions; this internal listener is deterministic and testable.
+func (a *App) startCheckServer() error {
+	addr := a.CheckAddr
+	if addr == "" {
+		addr = defaultCheckAddr
 	}
-	_, ok := a.rt.registry.lookupByHost(domain)
-	if !ok {
-		w.WriteHeader(http.StatusForbidden)
-		return nil
+
+	ln, err := net.Listen("tcp", addr)
+	if err != nil {
+		return fmt.Errorf("check server listen %s: %w", addr, err)
 	}
-	w.WriteHeader(http.StatusOK)
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/zero-trust/check-domain", a.serveCheckDomain)
+
+	srv := &http.Server{
+		Handler:           mux,
+		ReadHeaderTimeout: 5 * time.Second,
+	}
+	a.rt.checkServer = srv
+
+	go func() {
+		if err := srv.Serve(ln); err != nil && err != http.ErrServerClosed {
+			log.Error("ztagents: check server: %v", err)
+		}
+	}()
+
+	log.Info("ztagents: check server listening on %s", addr)
 	return nil
 }
 
-var _ caddy.AdminRouter = (*App)(nil)
+func (a *App) stopCheckServer() {
+	if a.rt == nil || a.rt.checkServer == nil {
+		return
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	_ = a.rt.checkServer.Shutdown(ctx)
+}
+
+func (a *App) serveCheckDomain(w http.ResponseWriter, r *http.Request) {
+	domain := r.URL.Query().Get("domain")
+	if domain == "" || a.rt == nil {
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+	if _, ok := a.rt.registry.lookupByHost(domain); !ok {
+		w.WriteHeader(http.StatusForbidden)
+		return
+	}
+	w.WriteHeader(http.StatusOK)
+}

--- a/modules/ztagents/app.go
+++ b/modules/ztagents/app.go
@@ -6,6 +6,7 @@ import (
 	"crypto/x509"
 	"fmt"
 	"net"
+	"net/http"
 	"os"
 	"strings"
 	"sync"
@@ -27,18 +28,20 @@ type App struct {
 	CertFile   string `json:"cert_file,omitempty"`
 	KeyFile    string `json:"key_file,omitempty"`
 	CAFile     string `json:"ca_file,omitempty"`
+	CheckAddr  string `json:"check_addr,omitempty"`
 
 	rt *runtime
 }
 
 type runtime struct {
-	tlsConfig *tls.Config
-	listener  net.Listener
-	registry  *registry
-	wsManager *common.WebSocketManager
-	ctx       context.Context
-	cancelCtx context.CancelFunc
-	wg        sync.WaitGroup
+	tlsConfig   *tls.Config
+	listener    net.Listener
+	registry    *registry
+	wsManager   *common.WebSocketManager
+	checkServer *http.Server
+	ctx         context.Context
+	cancelCtx   context.CancelFunc
+	wg          sync.WaitGroup
 }
 
 func (App) CaddyModule() caddy.ModuleInfo {
@@ -90,6 +93,10 @@ func (a *App) Start() error {
 
 	log.Info("ztagents: listening on %s", a.ListenAddr)
 
+	if err := a.startCheckServer(); err != nil {
+		return fmt.Errorf("ztagents: start check server: %w", err)
+	}
+
 	a.rt.wg.Add(1)
 	go a.acceptLoop()
 	return nil
@@ -98,6 +105,7 @@ func (a *App) Start() error {
 func (a *App) Stop() error {
 	log.Info("ztagents: stopping")
 	a.rt.cancelCtx()
+	a.stopCheckServer()
 	if a.rt.listener != nil {
 		_ = a.rt.listener.Close()
 	}

--- a/modules/ztagents/caddyfile.go
+++ b/modules/ztagents/caddyfile.go
@@ -53,6 +53,10 @@ func (a *App) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 				if !d.Args(&a.CAFile) {
 					return d.ArgErr()
 				}
+			case "check_addr":
+				if !d.Args(&a.CheckAddr) {
+					return d.ArgErr()
+				}
 			default:
 				return d.Errf("unknown zerotrust_agents option %q", d.Val())
 			}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added domain verification endpoint for secure on-demand TLS certificate issuance.
  * New `check_addr` configuration option to customize the verification server address.

* **Configuration**
  * Updated certificate paths to use absolute paths for improved consistency.
  * Enhanced HTTP redirect behavior with automatic HTTPS enforcement and ACME challenge support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Replace unreliable Caddy admin API routing with internal HTTP listener for domain validation checks, and fix chunked streaming detection for unbounded responses.

Main changes:
- Replaced Caddy AdminRouter with dedicated localhost HTTP server in startCheckServer/stopCheckServer for /zero-trust/check-domain endpoint
- Added contentLength < 0 check to ShouldStream to buffer unbounded chunked transfers, preventing memory exhaustion
- Added CheckAddr configuration option and improved Caddyfile HTTP-HTTPS redirect with ACME challenge exclusion

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
