### PR TITLE
fix: emit IsLastChunk terminator on clean EOF

### DIFF
--- a/internal/streaming/download.go
+++ b/internal/streaming/download.go
@@ -122,8 +122,27 @@ func (ds *DownloadStreamer) StreamResponse(resp *http.Response, msgID string) er
 		}
 
 		if err == io.EOF {
-			// Handle EOF without data read in this iteration
+			// Handle EOF without data read in this iteration. The body ended
+			// cleanly on a prior Read (n>0, err=nil) and this Read returns
+			// (0, EOF). We must still emit a final IsLastChunk=true marker
+			// so the router knows the stream is complete — otherwise it
+			// waits for the next chunk and eventually times out.
 			if n == 0 {
+				ds.stream.ChunkIndex++
+				finalMsg := &common.Message{
+					Type: "http_response",
+					ID:   msgID,
+					HTTP: &common.HTTPData{
+						IsStream:    true,
+						ChunkSize:   0,
+						TotalSize:   ds.stream.TotalSize,
+						ChunkIndex:  ds.stream.ChunkIndex,
+						IsLastChunk: true,
+					},
+				}
+				if sendErr := ds.sender.SendMessage(finalMsg); sendErr != nil {
+					return fmt.Errorf("failed to send final chunk marker: %v", sendErr)
+				}
 				log.Debug("🔚 Reached EOF, download stream complete: ID=%s", ds.stream.ID)
 				return nil
 			}


### PR DESCRIPTION
When resp.Body.Read returns (n=0, io.EOF) — the common case for chunked                                                                                                                                                                                                               
  bodies whose last Read returned data with nil error — the agent-side                                                                                                                                                                                                                  
  streamer returned without sending a terminator message. The router                                                                                                                                                                                                                    
  kept waiting on respCh for the next chunk and hit the 60s timeout,
  manifesting as slow or failing page loads (e.g., the Synology DSM                                                                                                                                                                                                                     
  login: 11666 bytes delivered, then router hangs waiting for chunk 5).                                                                                                                                                                                                                 
                                                                                                                                                                                                                                                                                        
  Emit one final http_response with IsStream=true, empty body, and                                                                                                                                                                                                                      
  IsLastChunk=true before returning so both the HTTP/1.1 hijack path                                                                                                                                                                                                                    
  and the HTTP/2 flush path see the stream close cleanly.                                                                                                                                                                                                                               
                                                                                                                                                                                                                                                                                        
  The bug was latent until ShouldStream started returning true for                                                                                                                                                                                                                      
  contentLength < 0 (chunked) — previously those responses went through                                                                                                                                                                                                                 
  the buffered writeAgentResponse path and never hit the streamer.                      