### PR TITLE
fix: Symmetric bug to the download one. The server-side upload streamer

### DIFF
--- a/internal/streaming/upload.go
+++ b/internal/streaming/upload.go
@@ -124,8 +124,14 @@ func (us *UploadStreamer) StreamFromConnection(conn net.Conn, msgID string, expe
 		}
 
 		if err == io.EOF {
-			// Handle EOF without data read in this iteration
+			// Handle EOF without data read in this iteration. The body ended
+			// cleanly on a prior Read and this one returns (0, EOF). Send a
+			// final IsLastChunk=true marker so the receiver closes its pipe
+			// instead of waiting forever for the next chunk.
 			if n == 0 {
+				if sendErr := us.sendFinalUploadMarker(msgID); sendErr != nil {
+					return fmt.Errorf("failed to send final upload marker: %v", sendErr)
+				}
 				log.Debug("🔚 Reached EOF, upload stream complete: ID=%s", us.stream.ID)
 				return nil
 			}
@@ -317,8 +323,12 @@ func (us *UploadStreamer) StreamFromReader(reader io.Reader, msgID string) error
 		}
 
 		if err == io.EOF {
-			// Handle EOF without data read in this iteration
+			// Handle EOF without data read in this iteration. Send a final
+			// IsLastChunk=true marker so the receiver closes its pipe.
 			if n == 0 {
+				if sendErr := us.sendFinalUploadMarker(msgID); sendErr != nil {
+					return fmt.Errorf("failed to send final upload marker: %v", sendErr)
+				}
 				log.Debug("🔚 Reached EOF, upload stream complete: ID=%s", us.stream.ID)
 				return nil
 			}
@@ -411,8 +421,14 @@ func (us *UploadStreamer) StreamFromReaderWithContext(reader io.Reader, msgID st
 		}
 
 		if err == io.EOF {
-			// Handle EOF without data read in this iteration
+			// Handle EOF without data read in this iteration. Send a final
+			// IsLastChunk=true marker so the agent's pipe writer closes and
+			// the upstream POST completes; otherwise the agent hangs waiting
+			// for the next chunk and the client times out.
 			if n == 0 {
+				if sendErr := us.sendFinalUploadMarker(msgID); sendErr != nil {
+					return fmt.Errorf("failed to send final upload marker: %v", sendErr)
+				}
 				log.Debug("🔚 Reached EOF, upload stream complete: ID=%s", us.stream.ID)
 				return nil
 			}
@@ -420,6 +436,24 @@ func (us *UploadStreamer) StreamFromReaderWithContext(reader io.Reader, msgID st
 			return fmt.Errorf("error reading upload data: %v", err)
 		}
 	}
+}
+
+// sendFinalUploadMarker sends an empty http_upload_chunk with IsLastChunk=true
+// so the receiver knows the upload is complete. Required when the source
+// reader returns (0, io.EOF) without coalescing EOF with the final data read.
+func (us *UploadStreamer) sendFinalUploadMarker(msgID string) error {
+	us.stream.ChunkIndex++
+	return us.sender.SendMessage(&common.Message{
+		Type: "http_upload_chunk",
+		ID:   msgID,
+		HTTP: &common.HTTPData{
+			IsStream:    true,
+			ChunkSize:   0,
+			TotalSize:   us.stream.TotalSize,
+			ChunkIndex:  us.stream.ChunkIndex,
+			IsLastChunk: true,
+		},
+	})
 }
 
 // ShouldStreamUpload determines if an upload should be streamed based on content length


### PR DESCRIPTION
What this fixes: Symmetric bug to the download one. The server-side upload streamer returned on (n=0, io.EOF) without sending IsLastChunk=true. The agent's StreamToRequest at upload.go:214 waits on uploadChan for that flag before closing its pipe writer — so the 250MB body     
  fully reached the agent but the POST to the Synology backend never finalized, and the client sat waiting for a response that would never come.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced upload stream completion to properly send a terminal marker upon reaching the end of a stream, ensuring uploads are correctly finalized and acknowledged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Fix upload stream completion signaling by sending final EOF marker to prevent receiver from hanging when source reader returns EOF without coalescing final data.

Main changes:
- Added `sendFinalUploadMarker()` method that sends empty http_upload_chunk with IsLastChunk=true flag to signal upload completion
- Updated three streaming methods (StreamFromConnection, StreamFromReader, StreamFromReaderWithContext) to call marker on EOF with n==0

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
