### PR TITLE
   fix: SSE inter-chunk timeout + premature upload context cancellation

### DIFF
--- a/internal/streaming/upload.go
+++ b/internal/streaming/upload.go
@@ -157,8 +157,6 @@ func (us *UploadStreamer) StreamFromConnection(conn net.Conn, msgID string, expe
 
 // StreamToRequest streams upload chunks to an HTTP request body (agent-side)
 func (us *UploadStreamer) StreamToRequest(uploadChan <-chan *common.Message, req *http.Request) error {
-	defer us.stream.Close()
-
 	log.Info("📤 Starting upload stream to request: ID=%s", us.stream.ID)
 
 	// Create a pipe for streaming the request body
@@ -167,6 +165,11 @@ func (us *UploadStreamer) StreamToRequest(uploadChan <-chan *common.Message, req
 
 	// Start a goroutine to write chunks to the pipe
 	go func() {
+		// Close the stream (and its context) only when the goroutine exits, not
+		// when StreamToRequest returns. Moving the close here prevents a race
+		// where the context was cancelled immediately on function return, causing
+		// ctx.Done() to fire in the select below when uploadChan was briefly empty.
+		defer us.stream.Close()
 		defer pipeWriter.Close()
 
 		lastProgressTime := time.Now()

--- a/modules/ztrouter/download.go
+++ b/modules/ztrouter/download.go
@@ -3,6 +3,7 @@ package ztrouter
 import (
 	"fmt"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/devhatro/zero-trust-proxy/internal/common"
@@ -21,6 +22,7 @@ import (
 // http.Flusher to push each chunk instead.
 func (h *Handler) handleDownloadStream(
 	w http.ResponseWriter,
+	r *http.Request,
 	agent *ztagents.Agent,
 	msgID string,
 	initial *common.Message,
@@ -30,7 +32,7 @@ func (h *Handler) handleDownloadStream(
 		return h.streamDownloadHijack(w, hijacker, agent, msgID, initial, respCh)
 	}
 	if flusher, ok := w.(http.Flusher); ok {
-		return h.streamDownloadFlush(w, flusher, agent, msgID, initial, respCh)
+		return h.streamDownloadFlush(w, r, flusher, agent, msgID, initial, respCh)
 	}
 	http.Error(w, "Streaming not supported", http.StatusInternalServerError)
 	return nil
@@ -65,6 +67,7 @@ func (h *Handler) streamDownloadHijack(
 
 func (h *Handler) streamDownloadFlush(
 	w http.ResponseWriter,
+	r *http.Request,
 	flusher http.Flusher,
 	agent *ztagents.Agent,
 	msgID string,
@@ -85,14 +88,33 @@ func (h *Handler) streamDownloadFlush(
 	w.WriteHeader(status)
 	flusher.Flush()
 
-	log.Info("ztrouter: download stream (h2) id=%s size=%d agent=%s",
-		msgID, initial.HTTP.TotalSize, agent.ID)
+	// SSE connections send infrequent events; the default 60s inter-chunk
+	// timeout kills them prematurely. Detect by Content-Type and use a
+	// long sentinel timeout instead — the client disconnect (ctx.Done) or
+	// a write error will terminate the loop in the normal case.
+	isSSE := false
+	if ct := initial.HTTP.Headers["Content-Type"]; len(ct) > 0 {
+		isSSE = strings.Contains(strings.ToLower(ct[0]), "text/event-stream")
+	}
+
+	streamKind := "h2"
+	if isSSE {
+		streamKind = "h2/sse"
+	}
+	log.Info("ztrouter: download stream (%s) id=%s size=%d agent=%s",
+		streamKind, msgID, initial.HTTP.TotalSize, agent.ID)
 
 	timeoutCfg := common.DefaultTimeouts()
 	var transferred int64
 	var chunkIdx int
 	for {
-		dyn := common.CalculateStreamingTimeout(initial.HTTP.TotalSize, transferred, timeoutCfg)
+		var dyn time.Duration
+		if isSSE {
+			// Rely on ctx.Done (client disconnect) and write errors to terminate.
+			dyn = 24 * time.Hour
+		} else {
+			dyn = common.CalculateStreamingTimeout(initial.HTTP.TotalSize, transferred, timeoutCfg)
+		}
 		select {
 		case chunk, ok := <-respCh:
 			if !ok {
@@ -110,13 +132,17 @@ func (h *Handler) streamDownloadFlush(
 				chunkIdx++
 			}
 			if chunk.HTTP.IsLastChunk {
-				log.Info("ztrouter: download stream (h2) done id=%s chunks=%d bytes=%d",
-					msgID, chunkIdx, transferred)
+				log.Info("ztrouter: download stream (%s) done id=%s chunks=%d bytes=%d",
+					streamKind, msgID, chunkIdx, transferred)
 				return nil
 			}
 		case <-time.After(dyn):
 			return fmt.Errorf("timeout waiting for chunk %d after %v (received %d bytes)",
 				chunkIdx+1, dyn, transferred)
+		case <-r.Context().Done():
+			log.Debug("ztrouter: download stream (%s) cancelled by client id=%s chunks=%d bytes=%d",
+				streamKind, msgID, chunkIdx, transferred)
+			return nil
 		}
 	}
 }

--- a/modules/ztrouter/handler.go
+++ b/modules/ztrouter/handler.go
@@ -144,7 +144,7 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request, _ caddyhttp.
 			return h.handleWebSocketUpgrade(w, agent, msgID, resp)
 		}
 		if resp.HTTP != nil && resp.HTTP.IsStream {
-			return h.handleDownloadStream(w, agent, msgID, resp, respCh)
+			return h.handleDownloadStream(w, r, agent, msgID, resp, respCh)
 		}
 		return writeAgentResponse(w, resp)
 	case <-r.Context().Done():


### PR DESCRIPTION
   Two bugs:

   1. streamDownloadFlush used a 60s inter-chunk timeout for all streams. SSE endpoints send infrequent events, so the proxy killed connections before the next event arrived. Fix: detect text/event-stream Content-Type and use a 24h sentinel timeout; thread r.Context() so client disconnects still terminate the loop cleanly.

   2. StreamToRequest had `defer us.stream.Close()` in the function body, which fired immediately on return (right after goroutine launch). The cancelled context caused ctx.Done() to win the select whenever uploadChan was briefly empty, aborting uploads mid-stream with "upload stream context cancelled". Fix: move the defer into the goroutine so the context lives until the goroutine exits.