### PR TITLE
test: expand coverage for agent HTTP paths, Stop/health-check lifecycle

### DIFF
--- a/internal/agent/agent_helpers_test.go
+++ b/internal/agent/agent_helpers_test.go
@@ -3,6 +3,7 @@ package agent
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net"
 	"net/http"
@@ -651,4 +652,278 @@ func TestSendBackendResponse_StreamingResponse(t *testing.T) {
 	}
 
 	<-done
+}
+
+// --- handleHTTPRequest additional branches ---
+
+func TestHandleHTTPRequest_NilConn(t *testing.T) {
+	a := newTestAgent()
+	a.reconnectInProgress = true // prevent real dial attempt
+	// conn is nil → agent calls attemptReconnection then returns; no panic.
+	a.handleHTTPRequest(&common.Message{
+		ID: "req-nil-conn",
+		HTTP: &common.HTTPData{
+			Method:  "GET",
+			URL:     "/",
+			Headers: map[string][]string{"Host": {"example.com"}},
+		},
+	})
+}
+
+func TestHandleHTTPRequest_MissingHost(t *testing.T) {
+	a, client := newConnectedAgent(t)
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		a.handleHTTPRequest(&common.Message{
+			ID:   "req-no-host",
+			HTTP: &common.HTTPData{Method: "GET", URL: "/"},
+		})
+	}()
+
+	_ = client.SetReadDeadline(time.Now().Add(2 * time.Second))
+	var resp common.Message
+	if err := json.NewDecoder(client).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	<-done
+	if resp.Error == "" {
+		t.Fatal("expected error response for missing Host header")
+	}
+	if resp.ID != "req-no-host" {
+		t.Fatalf("id=%s, want req-no-host", resp.ID)
+	}
+}
+
+func TestHandleHTTPRequest_NoServiceForHost(t *testing.T) {
+	a, client := newConnectedAgent(t)
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		a.handleHTTPRequest(&common.Message{
+			ID: "req-no-svc",
+			HTTP: &common.HTTPData{
+				Method:  "GET",
+				URL:     "/",
+				Headers: map[string][]string{"Host": {"unknown.example.com"}},
+			},
+		})
+	}()
+
+	_ = client.SetReadDeadline(time.Now().Add(2 * time.Second))
+	var resp common.Message
+	if err := json.NewDecoder(client).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	<-done
+	if resp.Error == "" {
+		t.Fatal("expected error response when no service registered")
+	}
+}
+
+// TestHandleHTTPRequest_BackendWithProtocol tests the path where the service
+// Backend already includes an "http://" prefix (hasProtocol == true branch).
+func TestHandleHTTPRequest_BackendWithProtocol(t *testing.T) {
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("with-protocol"))
+	}))
+	defer backend.Close()
+
+	host := "proto.example.com"
+	a, clientConn := newConnectedAgent(t)
+	a.mu.Lock()
+	a.services[host] = &common.ServiceConfig{
+		ServiceConfig: types.ServiceConfig{
+			Hostname: host,
+			Backend:  backend.URL, // already has "http://" prefix
+			Protocol: "http",
+		},
+	}
+	a.mu.Unlock()
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		a.handleHTTPRequest(&common.Message{
+			ID: "req-proto",
+			HTTP: &common.HTTPData{
+				Method:  "GET",
+				URL:     "/",
+				Headers: map[string][]string{"Host": {host}},
+			},
+		})
+	}()
+
+	_ = clientConn.SetReadDeadline(time.Now().Add(3 * time.Second))
+	var resp common.Message
+	if err := json.NewDecoder(clientConn).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	<-done
+	if resp.HTTP == nil || resp.HTTP.StatusCode != 200 {
+		t.Fatalf("expected 200, got %+v", resp.HTTP)
+	}
+	if string(resp.HTTP.Body) != "with-protocol" {
+		t.Fatalf("body=%q, want with-protocol", resp.HTTP.Body)
+	}
+}
+
+// TestHandleHTTPRequest_HTTPSBackend tests service.Protocol=="https", which
+// triggers the https URL-building branch and InsecureSkipVerify TLS transport.
+func TestHandleHTTPRequest_HTTPSBackend(t *testing.T) {
+	backend := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("https-ok"))
+	}))
+	defer backend.Close()
+
+	host := "https-svc.example.com"
+	a, clientConn := newConnectedAgent(t)
+	a.mu.Lock()
+	a.services[host] = &common.ServiceConfig{
+		ServiceConfig: types.ServiceConfig{
+			Hostname: host,
+			Backend:  backend.Listener.Addr().String(), // no protocol prefix
+			Protocol: "https",                          // triggers protocol = "https" branch
+		},
+	}
+	a.mu.Unlock()
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		a.handleHTTPRequest(&common.Message{
+			ID: "req-https",
+			HTTP: &common.HTTPData{
+				Method:  "GET",
+				URL:     "/",
+				Headers: map[string][]string{"Host": {host}},
+			},
+		})
+	}()
+
+	_ = clientConn.SetReadDeadline(time.Now().Add(3 * time.Second))
+	var resp common.Message
+	if err := json.NewDecoder(clientConn).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	<-done
+	if resp.HTTP == nil || resp.HTTP.StatusCode != 200 {
+		t.Fatalf("expected 200, got %+v", resp.HTTP)
+	}
+}
+
+// TestHandleHTTPRequest_WithXForwardedFor exercises the clientIP extraction
+// branch when X-Forwarded-For is present in the request.
+func TestHandleHTTPRequest_WithXForwardedFor(t *testing.T) {
+	var gotXRealIP string
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotXRealIP = r.Header.Get("X-Real-IP")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("xff-ok"))
+	}))
+	defer backend.Close()
+
+	host := "xff.example.com"
+	a, clientConn := newConnectedAgent(t)
+	a.mu.Lock()
+	a.services[host] = &common.ServiceConfig{
+		ServiceConfig: types.ServiceConfig{
+			Hostname: host,
+			Backend:  backend.Listener.Addr().String(),
+			Protocol: "http",
+		},
+	}
+	a.mu.Unlock()
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		a.handleHTTPRequest(&common.Message{
+			ID: "req-xff",
+			HTTP: &common.HTTPData{
+				Method: "GET",
+				URL:    "/",
+				Headers: map[string][]string{
+					"Host":            {host},
+					"X-Forwarded-For": {"10.0.0.1, 10.0.0.2"},
+				},
+			},
+		})
+	}()
+
+	_ = clientConn.SetReadDeadline(time.Now().Add(3 * time.Second))
+	var resp common.Message
+	if err := json.NewDecoder(clientConn).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	<-done
+	if resp.HTTP == nil || resp.HTTP.StatusCode != 200 {
+		t.Fatalf("expected 200, got %+v", resp.HTTP)
+	}
+	if gotXRealIP != "10.0.0.1" {
+		t.Fatalf("X-Real-IP=%q, want 10.0.0.1", gotXRealIP)
+	}
+}
+
+// TestHandleHTTPRequest_StreamingResponse tests the streaming download path
+// inside handleHTTPRequest (content large enough to trigger ShouldStream).
+func TestHandleHTTPRequest_StreamingResponse(t *testing.T) {
+	const size = 2 * 1024 * 1024
+	body := bytes.Repeat([]byte("s"), size)
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/octet-stream")
+		w.Header().Set("Content-Length", fmt.Sprintf("%d", size))
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(body)
+	}))
+	defer backend.Close()
+
+	host := "big.example.com"
+	a, clientConn := newConnectedAgent(t)
+	a.mu.Lock()
+	a.services[host] = &common.ServiceConfig{
+		ServiceConfig: types.ServiceConfig{
+			Hostname: host,
+			Backend:  backend.Listener.Addr().String(),
+			Protocol: "http",
+		},
+	}
+	a.mu.Unlock()
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		a.handleHTTPRequest(&common.Message{
+			ID: "req-stream",
+			HTTP: &common.HTTPData{
+				Method:  "GET",
+				URL:     "/",
+				Headers: map[string][]string{"Host": {host}},
+			},
+		})
+	}()
+
+	_ = clientConn.SetReadDeadline(time.Now().Add(10 * time.Second))
+	dec := json.NewDecoder(clientConn)
+	var gotLast bool
+	for !gotLast {
+		var msg common.Message
+		if err := dec.Decode(&msg); err != nil {
+			break
+		}
+		if msg.HTTP != nil && msg.HTTP.IsLastChunk {
+			gotLast = true
+		}
+		if msg.Type == "http_response" && msg.HTTP != nil && !msg.HTTP.IsStream {
+			gotLast = true
+		}
+	}
+	<-done
+	if !gotLast {
+		t.Fatal("expected streaming response to complete with IsLastChunk or http_response")
+	}
 }

--- a/internal/agent/utils_test.go
+++ b/internal/agent/utils_test.go
@@ -3,6 +3,9 @@ package agent
 import (
 	"encoding/json"
 	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
 	"strings"
 	"testing"
 	"time"
@@ -703,3 +706,223 @@ func TestUpdateServicesFromConfig_UpdateService(t *testing.T) {
 	// exercise the comparison code path.
 	_ = a.updateServicesFromConfig(newConfig)
 }
+
+// --- Stop ---
+
+func TestStop_Basic(t *testing.T) {
+	a := newTestAgent()
+	a.Stop()
+	select {
+	case <-a.stopCh:
+		// closed as expected
+	default:
+		t.Fatal("stopCh should be closed after Stop()")
+	}
+}
+
+func TestStop_Idempotent(t *testing.T) {
+	a := newTestAgent()
+	a.Stop()
+	// Second call must not panic (select on already-closed channel).
+	a.Stop()
+}
+
+// --- runHealthCheck ---
+
+func TestRunHealthCheck_NilHealthCheck(t *testing.T) {
+	a := newTestAgent()
+	svc := &ServiceConfig{ID: "test"}
+	up := UpstreamConfig{Address: "127.0.0.1:9999"} // nil HealthCheck
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		a.runHealthCheck(svc, up)
+	}()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("runHealthCheck with nil HealthCheck should return immediately")
+	}
+}
+
+func TestRunHealthCheck_StopsOnSignal(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	u, err := url.Parse(srv.URL)
+	if err != nil {
+		t.Fatalf("parse URL: %v", err)
+	}
+
+	a := newTestAgent()
+	svc := &ServiceConfig{ID: "svc-hc", Protocol: "http"}
+	up := UpstreamConfig{
+		Address: u.Host,
+		HealthCheck: &HealthCheckConfig{
+			Path:     "/",
+			Interval: 20 * time.Millisecond,
+			Timeout:  500 * time.Millisecond,
+		},
+	}
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		a.runHealthCheck(svc, up)
+	}()
+
+	time.Sleep(30 * time.Millisecond) // allow at least one tick
+	a.Stop()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("runHealthCheck did not exit after Stop()")
+	}
+}
+
+// --- handleUploadStart early exit paths ---
+
+func TestHandleUploadStart_NilHTTP(t *testing.T) {
+	a := newTestAgent()
+	ch := make(chan *common.Message, 1)
+	// nil HTTP data → return early, cleanup channel map.
+	a.handleUploadStart(&common.Message{ID: "up-nil"}, ch)
+	a.uploadMu.Lock()
+	_, ok := a.uploadChans["up-nil"]
+	a.uploadMu.Unlock()
+	if ok {
+		t.Fatal("uploadChans entry should be removed after handleUploadStart")
+	}
+}
+
+func TestHandleUploadStart_NilConn(t *testing.T) {
+	a := newTestAgent()
+	ch := make(chan *common.Message, 1)
+	// nil conn → return early after warning log.
+	a.handleUploadStart(&common.Message{
+		ID:   "up-no-conn",
+		HTTP: &common.HTTPData{Headers: map[string][]string{"Host": {"example.com"}}},
+	}, ch)
+}
+
+func TestHandleUploadStart_MissingHost(t *testing.T) {
+	a, _ := newConnectedAgent(t)
+	ch := make(chan *common.Message, 1)
+	// Empty headers — missing Host → return early.
+	a.handleUploadStart(&common.Message{
+		ID:   "up-no-host",
+		HTTP: &common.HTTPData{Method: "POST", URL: "/up", Headers: map[string][]string{}},
+	}, ch)
+}
+
+func TestHandleUploadStart_NoServiceForHost(t *testing.T) {
+	a, _ := newConnectedAgent(t)
+	ch := make(chan *common.Message, 1)
+	// Host present but no service registered for it → return early.
+	a.handleUploadStart(&common.Message{
+		ID: "up-no-svc",
+		HTTP: &common.HTTPData{
+			Method:  "POST",
+			URL:     "/up",
+			Headers: map[string][]string{"Host": {"unknown.upload.example.com"}},
+		},
+	}, ch)
+}
+
+// --- convertToCommonEnhancedServiceConfig (full optional fields) ---
+
+func TestConvertToCommonEnhancedServiceConfig_FullConfig(t *testing.T) {
+	a := newTestAgent()
+	svc := &ServiceConfig{
+		ID: "full-svc",
+		TLS: &TLSConfig{
+			CertFile:   "/cert.crt",
+			KeyFile:    "/key.key",
+			CAFile:     "/ca.crt",
+			MinVersion: "1.3",
+			ClientAuth: "require",
+		},
+		Security: &SecurityConfig{
+			CORS: &CORSConfig{
+				Origins: []string{"https://example.com"},
+				Methods: []string{"GET", "POST"},
+				Headers: []string{"Authorization"},
+			},
+			Auth: &AuthConfig{
+				Type:   "bearer",
+				Config: map[string]interface{}{"key": "value"},
+			},
+		},
+		Monitoring: &MonitoringConfig{
+			MetricsEnabled: true,
+			LoggingFormat:  "json",
+			LoggingFields:  []string{"request_id"},
+		},
+		TrafficShaping: &TrafficShapingConfig{
+			UploadLimit:   "100mbps",
+			DownloadLimit: "200mbps",
+			PerIPLimit:    "10mbps",
+		},
+	}
+	result := a.convertToCommonEnhancedServiceConfig(svc, "full.example.com")
+
+	if result.TLS == nil || result.TLS.CertFile != "/cert.crt" {
+		t.Fatalf("TLS not populated: %+v", result.TLS)
+	}
+	if result.Security == nil || result.Security.CORS == nil {
+		t.Fatal("Security.CORS should be present")
+	}
+	if len(result.Security.CORS.Origins) != 1 || result.Security.CORS.Origins[0] != "https://example.com" {
+		t.Fatalf("CORS.Origins=%v", result.Security.CORS.Origins)
+	}
+	if result.Security.Auth == nil || result.Security.Auth.Type != "bearer" {
+		t.Fatalf("Security.Auth=%+v", result.Security.Auth)
+	}
+	if result.Monitoring == nil || !result.Monitoring.MetricsEnabled {
+		t.Fatal("Monitoring.MetricsEnabled should be true")
+	}
+	if result.Monitoring.Logging == nil || result.Monitoring.Logging.Format != "json" {
+		t.Fatalf("Monitoring.Logging=%+v", result.Monitoring.Logging)
+	}
+	if result.TrafficShaping == nil || result.TrafficShaping.UploadLimit != "100mbps" {
+		t.Fatalf("TrafficShaping=%+v", result.TrafficShaping)
+	}
+}
+
+// TestConvertToCommonEnhancedServiceConfig_SecurityAuthOnly covers Security
+// with Auth but no CORS (both Security != nil and CORS == nil paths).
+func TestConvertToCommonEnhancedServiceConfig_SecurityAuthOnly(t *testing.T) {
+	a := newTestAgent()
+	svc := &ServiceConfig{
+		Security: &SecurityConfig{
+			Auth: &AuthConfig{Type: "api_key"},
+		},
+	}
+	result := a.convertToCommonEnhancedServiceConfig(svc, "auth.example.com")
+	if result.Security == nil || result.Security.Auth == nil {
+		t.Fatal("Security.Auth should be present")
+	}
+	if result.Security.CORS != nil {
+		t.Fatal("Security.CORS should be nil when not configured")
+	}
+}
+
+// TestConvertToCommonEnhancedServiceConfig_MonitoringNoLogging covers the
+// Monitoring branch when LoggingFormat and LoggingFields are empty.
+func TestConvertToCommonEnhancedServiceConfig_MonitoringNoLogging(t *testing.T) {
+	a := newTestAgent()
+	svc := &ServiceConfig{
+		Monitoring: &MonitoringConfig{MetricsEnabled: true}, // no LoggingFormat
+	}
+	result := a.convertToCommonEnhancedServiceConfig(svc, "metrics.example.com")
+	if result.Monitoring == nil {
+		t.Fatal("Monitoring should be present")
+	}
+	if result.Monitoring.Logging != nil {
+		t.Fatal("Monitoring.Logging should be nil when format/fields are empty")
+	}
+}
+

--- a/modules/ztagents/app_test.go
+++ b/modules/ztagents/app_test.go
@@ -1,12 +1,85 @@
 package ztagents
 
 import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
 	"errors"
+	"math/big"
+	"net"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
 	"github.com/caddyserver/caddy/v2"
 )
+
+// generateTestCerts creates a self-signed CA and a server cert signed by it,
+// writes them to a temp dir, and returns the file paths.
+func generateTestCerts(t *testing.T) (certFile, keyFile, caFile string) {
+	t.Helper()
+	dir := t.TempDir()
+
+	caKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("generate CA key: %v", err)
+	}
+	caTemplate := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "Test CA"},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(24 * time.Hour),
+		IsCA:                  true,
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
+		BasicConstraintsValid: true,
+	}
+	caDER, err := x509.CreateCertificate(rand.Reader, caTemplate, caTemplate, &caKey.PublicKey, caKey)
+	if err != nil {
+		t.Fatalf("create CA cert: %v", err)
+	}
+	caCert, _ := x509.ParseCertificate(caDER)
+
+	caFile = filepath.Join(dir, "ca.crt")
+	f, _ := os.Create(caFile)
+	_ = pem.Encode(f, &pem.Block{Type: "CERTIFICATE", Bytes: caDER})
+	f.Close()
+
+	srvKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("generate server key: %v", err)
+	}
+	srvTemplate := &x509.Certificate{
+		SerialNumber: big.NewInt(2),
+		Subject:      pkix.Name{CommonName: "test-server"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(24 * time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth, x509.ExtKeyUsageClientAuth},
+		IPAddresses:  []net.IP{net.ParseIP("127.0.0.1")},
+	}
+	srvDER, err := x509.CreateCertificate(rand.Reader, srvTemplate, caCert, &srvKey.PublicKey, caKey)
+	if err != nil {
+		t.Fatalf("create server cert: %v", err)
+	}
+
+	certFile = filepath.Join(dir, "server.crt")
+	f, _ = os.Create(certFile)
+	_ = pem.Encode(f, &pem.Block{Type: "CERTIFICATE", Bytes: srvDER})
+	f.Close()
+
+	keyFile = filepath.Join(dir, "server.key")
+	srvKeyDER, _ := x509.MarshalECPrivateKey(srvKey)
+	f, _ = os.Create(keyFile)
+	_ = pem.Encode(f, &pem.Block{Type: "EC PRIVATE KEY", Bytes: srvKeyDER})
+	f.Close()
+
+	return certFile, keyFile, caFile
+}
 
 // --- App.Validate ---
 
@@ -110,5 +183,59 @@ func TestStartCheckServer_DefaultAddr(t *testing.T) {
 	err := app.startCheckServer()
 	if err == nil {
 		app.stopCheckServer()
+	}
+}
+
+// --- loadTLSConfig success path ---
+
+func TestLoadTLSConfig_Success(t *testing.T) {
+	certFile, keyFile, caFile := generateTestCerts(t)
+	cfg, err := loadTLSConfig(certFile, keyFile, caFile)
+	if err != nil {
+		t.Fatalf("loadTLSConfig: %v", err)
+	}
+	if cfg == nil {
+		t.Fatal("expected non-nil TLS config")
+	}
+	if cfg.ClientAuth != tls.RequireAndVerifyClientCert {
+		t.Fatalf("ClientAuth=%v, want RequireAndVerifyClientCert", cfg.ClientAuth)
+	}
+	if cfg.MinVersion != tls.VersionTLS12 {
+		t.Fatalf("MinVersion=%v, want TLS 1.2", cfg.MinVersion)
+	}
+	if len(cfg.Certificates) != 1 {
+		t.Fatalf("Certificates len=%d, want 1", len(cfg.Certificates))
+	}
+	if cfg.ClientCAs == nil {
+		t.Fatal("ClientCAs pool should not be nil")
+	}
+}
+
+func TestLoadTLSConfig_EmptyCAPEM(t *testing.T) {
+	dir := t.TempDir()
+	// Write an empty CA file — AppendCertsFromPEM returns false.
+	caFile := filepath.Join(dir, "empty_ca.crt")
+	_ = os.WriteFile(caFile, []byte("not-a-cert"), 0o600)
+
+	certFile, keyFile, _ := generateTestCerts(t)
+	_, err := loadTLSConfig(certFile, keyFile, caFile)
+	if err == nil {
+		t.Fatal("expected error for invalid CA PEM")
+	}
+}
+
+func TestApp_Provision_WithCerts(t *testing.T) {
+	certFile, keyFile, caFile := generateTestCerts(t)
+	app := &App{
+		ListenAddr: ":0",
+		CertFile:   certFile,
+		KeyFile:    keyFile,
+		CAFile:     caFile,
+	}
+	if err := app.Provision(caddy.Context{}); err != nil {
+		t.Fatalf("Provision with valid certs: %v", err)
+	}
+	if app.rt == nil || app.rt.tlsConfig == nil {
+		t.Fatal("runtime.tlsConfig should be set after Provision with valid certs")
 	}
 }


### PR DESCRIPTION
- internal/agent: add tests for handleHTTPRequest error branches (nil conn, missing Host, no service), backend-with-protocol URL path, HTTPS backend with InsecureSkipVerify transport, X-Forwarded-For extraction, and streaming download response path
- internal/agent: cover Stop() idempotency and runHealthCheck goroutine lifecycle (exits on stopCh signal)
- internal/agent: cover handleUploadStart early-exit paths (nil HTTP, nil conn, missing Host, no service)
- internal/agent: cover convertToCommonEnhancedServiceConfig with TLS, Security (CORS + Auth), Monitoring (with/without logging), TrafficShaping
- modules/ztagents: cover loadTLSConfig success path and empty-CA-PEM error using in-test generated self-signed certs; cover Provision with valid certs

Coverage: internal/agent 52.5% → 56.9%, modules/ztagents 75.3% → 78.4%

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test coverage for HTTP request handling, including edge cases and protocol scenarios
  * Expanded agent lifecycle and configuration management testing
  * Added TLS certificate validation and configuration testing

<!-- end of auto-generated comment: release notes by coderabbit.ai -->