### PR TITLE
fix(ztrouter): add X-Forwarded headers for reverse proxy compatibility

### DIFF
--- a/modules/ztagents/handle_test.go
+++ b/modules/ztagents/handle_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/devhatro/zero-trust-proxy/internal/common"
 	"github.com/devhatro/zero-trust-proxy/internal/types"
+	"github.com/devhatro/zero-trust-proxy/modules/zttcp"
 )
 
 // newAppWithWS creates an App with both a registry and a WebSocket manager.
@@ -298,8 +299,9 @@ func TestHandleMessageNilMessage(t *testing.T) {
 
 func TestHandleAgentConnection_RegisterAndDisconnect(t *testing.T) {
 	app := &App{rt: &runtime{
-		registry:  newRegistry(),
-		wsManager: common.NewWebSocketManager(),
+		registry:   newRegistry(),
+		wsManager:  common.NewWebSocketManager(),
+		tcpManager: zttcp.NewManager(),
 	}}
 
 	client, server := net.Pipe()

--- a/modules/ztrouter/handler.go
+++ b/modules/ztrouter/handler.go
@@ -3,6 +3,7 @@ package ztrouter
 import (
 	"bytes"
 	"io"
+	"net"
 	"net/http"
 	"strings"
 	"sync/atomic"
@@ -71,6 +72,7 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		headers[k] = v
 	}
 	headers["Host"] = []string{host}
+	setForwardedHeaders(headers, r)
 
 	respCh := make(chan *common.Message, 16)
 	var closed int32
@@ -151,6 +153,42 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	case <-time.After(requestTimeout):
 		http.Error(w, "Agent response timeout", http.StatusGatewayTimeout)
+	}
+}
+
+// setForwardedHeaders populates X-Forwarded-For, X-Real-IP, X-Forwarded-Proto,
+// and X-Forwarded-Host based on r.RemoteAddr and the TLS state. The proxy is
+// the TLS termination point, so these values are authoritative.
+func setForwardedHeaders(headers map[string][]string, r *http.Request) {
+	host, _, err := net.SplitHostPort(r.RemoteAddr)
+	if err != nil {
+		host = r.RemoteAddr
+	}
+	host = strings.TrimPrefix(strings.TrimSuffix(host, "]"), "[")
+	if host != "" {
+		if existing, ok := headers["X-Forwarded-For"]; ok && len(existing) > 0 {
+			headers["X-Forwarded-For"] = []string{existing[0] + ", " + host}
+		} else {
+			headers["X-Forwarded-For"] = []string{host}
+		}
+		if _, ok := headers["X-Real-Ip"]; !ok {
+			if _, ok2 := headers["X-Real-IP"]; !ok2 {
+				headers["X-Real-Ip"] = []string{host}
+			}
+		}
+	}
+
+	proto := "http"
+	if r.TLS != nil {
+		proto = "https"
+	}
+	if _, ok := headers["X-Forwarded-Proto"]; !ok {
+		headers["X-Forwarded-Proto"] = []string{proto}
+	}
+	if _, ok := headers["X-Forwarded-Host"]; !ok {
+		if r.Host != "" {
+			headers["X-Forwarded-Host"] = []string{r.Host}
+		}
 	}
 }
 

--- a/modules/ztrouter/handler.go
+++ b/modules/ztrouter/handler.go
@@ -158,7 +158,8 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 // setForwardedHeaders populates X-Forwarded-For, X-Real-IP, X-Forwarded-Proto,
 // and X-Forwarded-Host based on r.RemoteAddr and the TLS state. The proxy is
-// the TLS termination point, so these values are authoritative.
+// the TLS termination point and is authoritative — any client-supplied values
+// for these headers are dropped to prevent spoofing.
 func setForwardedHeaders(headers map[string][]string, r *http.Request) {
 	host, _, err := net.SplitHostPort(r.RemoteAddr)
 	if err != nil {
@@ -166,29 +167,19 @@ func setForwardedHeaders(headers map[string][]string, r *http.Request) {
 	}
 	host = strings.TrimPrefix(strings.TrimSuffix(host, "]"), "[")
 	if host != "" {
-		if existing, ok := headers["X-Forwarded-For"]; ok && len(existing) > 0 {
-			headers["X-Forwarded-For"] = []string{existing[0] + ", " + host}
-		} else {
-			headers["X-Forwarded-For"] = []string{host}
-		}
-		if _, ok := headers["X-Real-Ip"]; !ok {
-			if _, ok2 := headers["X-Real-IP"]; !ok2 {
-				headers["X-Real-Ip"] = []string{host}
-			}
-		}
+		headers["X-Forwarded-For"] = []string{host}
+		delete(headers, "X-Real-Ip")
+		headers["X-Real-IP"] = []string{host}
 	}
 
 	proto := "http"
 	if r.TLS != nil {
 		proto = "https"
 	}
-	if _, ok := headers["X-Forwarded-Proto"]; !ok {
-		headers["X-Forwarded-Proto"] = []string{proto}
-	}
-	if _, ok := headers["X-Forwarded-Host"]; !ok {
-		if r.Host != "" {
-			headers["X-Forwarded-Host"] = []string{r.Host}
-		}
+	headers["X-Forwarded-Proto"] = []string{proto}
+
+	if r.Host != "" {
+		headers["X-Forwarded-Host"] = []string{r.Host}
 	}
 }
 


### PR DESCRIPTION
## Summary
- Added `setForwardedHeaders()` helper in ztrouter to populate X-Forwarded-For, X-Real-IP, X-Forwarded-Proto, and X-Forwarded-Host from the client connection
- The proxy is the TLS termination point, so these values are authoritative and must be passed to agents
- Fixes 403 errors from backends like Home Assistant that require proper reverse-proxy headers for client identification

## Test plan
- [x] Go tests pass (483 total)
- [x] ztrouter-specific tests pass (30 tests)
- [x] Build succeeds
- [] Manual: Deploy and confirm Home Assistant WebUI no longer returns 403
- [ ] Manual: Verify X-Forwarded-* headers are present in agent logs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced request forwarding to ensure proper tracking of client IP addresses and request protocols through proxy layers. Request headers are now consistently set to maintain critical routing information, improving compatibility with downstream services and proxy configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Add X-Forwarded headers to reverse proxy requests for proper client IP and protocol propagation while preventing header spoofing.

Main changes:
- Implemented setForwardedHeaders function extracting client IP from RemoteAddr and detecting TLS to populate X-Forwarded-For, X-Real-IP, X-Forwarded-Proto headers
- Updated ServeHTTP to invoke setForwardedHeaders, ensuring authoritative proxy headers override client-supplied values
- Fixed test initialization to properly instantiate tcpManager in runtime for TestHandleAgentConnection_RegisterAndDisconnect

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
