### PR TITLE
fix(ztrouter): preserve percent-encoded path separators across proxy hop

### DIFF
--- a/modules/ztrouter/handler.go
+++ b/modules/ztrouter/handler.go
@@ -183,11 +183,17 @@ func setForwardedHeaders(headers map[string][]string, r *http.Request) {
 	}
 }
 
+// requestURL returns the path (and query) to forward to the agent. It uses
+// EscapedPath rather than the decoded Path so that percent-encoded path
+// separators (%2F) survive the proxy hop intact. Backends that route on the
+// raw path — e.g. branch/ref names like "feature/x" or "release/1.2" carried
+// in a single path segment as "feature%2Fx" — would otherwise see an extra
+// segment after decoding and fail to match their route.
 func requestURL(r *http.Request) string {
 	if r.URL.RawQuery == "" {
-		return r.URL.Path
+		return r.URL.EscapedPath()
 	}
-	return r.URL.Path + "?" + r.URL.RawQuery
+	return r.URL.EscapedPath() + "?" + r.URL.RawQuery
 }
 
 func writeAgentResponse(w http.ResponseWriter, resp *common.Message) {

--- a/modules/ztrouter/handler_test.go
+++ b/modules/ztrouter/handler_test.go
@@ -408,3 +408,28 @@ func TestHandler_BodyReadError(t *testing.T) {
 type alwaysErrReader struct{}
 
 func (r *alwaysErrReader) Read(p []byte) (int, error) { return 0, io.ErrUnexpectedEOF }
+
+// TestRequestURL_PreservesEncodedSlash guards the proxy hop against collapsing
+// percent-encoded path separators. A backend that routes on the raw path (e.g.
+// a branch/ref name like "feature/x" carried as "feature%2Fx" in one segment)
+// gets an extra path segment and a spurious 404 if %2F is decoded here.
+func TestRequestURL_PreservesEncodedSlash(t *testing.T) {
+	tests := []struct {
+		name   string
+		target string
+		want   string
+	}{
+		{"encoded slash in segment", "http://h.example.com/api/pr/pr/38%2Fscans", "/api/pr/pr/38%2Fscans"},
+		{"encoded slash with query", "http://h.example.com/api/refs/feature%2Fx?full=1", "/api/refs/feature%2Fx?full=1"},
+		{"plain path unchanged", "http://h.example.com/hello/world", "/hello/world"},
+		{"plain path with query", "http://h.example.com/a/b?x=1&y=2", "/a/b?x=1&y=2"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, tt.target, nil)
+			if got := requestURL(req); got != tt.want {
+				t.Fatalf("requestURL() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Fixed `requestURL()` to use `EscapedPath()` instead of decoded `Path`, preserving `%2F` and other percent-encoded path bytes across the proxy hop to agents
- Added test coverage with encoded-slash and plain-path cases to prevent regression
- Resolves routing issues on backends that route by RawPath (e.g., refs with slashes)

## Test plan

- [x] Unit tests `TestRequestURL_PreservesEncodedSlash` pass with 4 cases (encoded slash in segment, with query, plain paths)
- [x] Full `modules/ztrouter` test suite (35 tests) passes
- [x] Verified no path-normalization elsewhere in proxy chain (`internal/server`, redirects)
<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Fix percent-encoded path separators (%2F) being decoded during proxy hops, causing routing failures on backend systems expecting raw paths.

Main changes:
- Modified requestURL() to use EscapedPath() instead of Path to preserve encoded separators across proxy forwarding
- Added comprehensive test cases verifying %2F preservation with and without query parameters in proxy requests

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed request routing to correctly preserve percent-encoded URL separators in request paths, ensuring URLs with encoded characters are handled properly.

* **Tests**
  * Added test coverage for encoded separator preservation in routing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DevHatRo/zero-trust-proxy/pull/43?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->