### PR TITLE
feat(ztrouter): serve branded error page when the agent is unreachable

### DIFF
--- a/internal/common/reqctx.go
+++ b/internal/common/reqctx.go
@@ -1,6 +1,10 @@
 package common
 
-import "context"
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+)
 
 // RequestInfo is a mutable holder threaded through request context so
 // the public-listener middleware (e.g. access log) can read values that
@@ -11,7 +15,26 @@ import "context"
 // context; downstream handlers fill in fields. Reads happen after
 // next.ServeHTTP returns, so no synchronization is needed.
 type RequestInfo struct {
+	// AgentID is the agent resolved for the request's Host (set by ztrouter).
 	AgentID string
+	// RequestID is a short opaque per-request identifier surfaced to clients
+	// (the X-Request-Id header and the error page) so a user-reported failure
+	// can be correlated with a log line. Set by the access-log middleware.
+	RequestID string
+}
+
+// NewRequestID returns a short, opaque, URL-safe request identifier (16 hex
+// chars from 8 random bytes). It is the project's "Ray ID" equivalent: shown
+// on error pages and emitted in access logs so a reported failure maps to a
+// log line. On the (practically impossible) RNG failure it returns a fixed
+// sentinel rather than an error — a non-unique ID is preferable to failing
+// the request over a cosmetic identifier.
+func NewRequestID() string {
+	var b [8]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		return "0000000000000000"
+	}
+	return hex.EncodeToString(b[:])
 }
 
 type requestInfoKey struct{}

--- a/internal/server/accesslog.go
+++ b/internal/server/accesslog.go
@@ -28,7 +28,7 @@ import (
 func accessLogMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		start := time.Now()
-		ri := &common.RequestInfo{}
+		ri := &common.RequestInfo{RequestID: common.NewRequestID()}
 		r = r.WithContext(common.WithRequestInfo(r.Context(), ri))
 		rw := &accessLogRecorder{ResponseWriter: w, status: http.StatusOK}
 		next.ServeHTTP(rw, r)
@@ -42,6 +42,7 @@ func accessLogMiddleware(next http.Handler) http.Handler {
 			Bytes      int64  `json:"bytes"`
 			DurationMS int64  `json:"duration_ms"`
 			AgentID    string `json:"agent_id,omitempty"`
+			RequestID  string `json:"request_id,omitempty"`
 			ClientIP   string `json:"client_ip,omitempty"`
 		}{
 			TS:         start.UTC().Format(time.RFC3339Nano),
@@ -52,6 +53,7 @@ func accessLogMiddleware(next http.Handler) http.Handler {
 			Bytes:      rw.bytes,
 			DurationMS: time.Since(start).Milliseconds(),
 			AgentID:    ri.AgentID,
+			RequestID:  ri.RequestID,
 			ClientIP:   clientIP(r.RemoteAddr),
 		}
 		b, err := json.Marshal(entry)

--- a/modules/ztrouter/errorpage.go
+++ b/modules/ztrouter/errorpage.go
@@ -1,0 +1,256 @@
+package ztrouter
+
+import (
+	"html/template"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/devhatro/zero-trust-proxy/internal/common"
+)
+
+// The three legs of the request path, in order. An error page highlights the
+// leg that failed; everything before it is shown as healthy, everything after
+// as unknown.
+const (
+	nodeClient = "client"
+	nodeProxy  = "proxy"
+	nodeAgent  = "agent"
+)
+
+// proxyError describes a gateway-level failure to render. It is the input to
+// writeProxyError, which decides between an HTML page (browsers) and a plain
+// text body (API clients) based on the request's Accept header.
+type proxyError struct {
+	Status  int    // HTTP status code written to the client
+	Title   string // short headline, e.g. "Agent Unreachable"
+	Summary string // one-sentence explanation for a human
+	Advice  string // "what can I do" guidance
+	Detail  string // technical detail (raw error); LOGGED ONLY, never shown to the client
+	Failed  string // which node failed: nodeClient | nodeProxy | nodeAgent
+}
+
+// writeProxyError writes a gateway error to the client. Browsers (Accept
+// contains text/html) get the branded status page; everything else gets a
+// compact plain-text body so curl/JSON clients aren't handed a wall of markup.
+// In both cases the request ID is echoed in the X-Request-Id header and logged
+// so a user-reported failure can be traced to a log line.
+func writeProxyError(w http.ResponseWriter, r *http.Request, pe proxyError) {
+	reqID := requestID(r)
+	host := r.Host
+
+	w.Header().Set("X-Request-Id", reqID)
+	// The response varies by Accept (HTML vs plain text) and must never be
+	// cached — a stored 502 would outlive the outage.
+	w.Header().Set("Vary", "Accept")
+	w.Header().Set("Cache-Control", "no-store")
+
+	// Detail (a raw error string that can contain internal addresses) is kept
+	// server-side only: it is logged with the request ID so an operator can
+	// trace a client-reported failure, but never written to the client.
+	logLine := "ztrouter: %s -> %d host=%s id=%s"
+	if pe.Detail != "" {
+		log.Error(logLine+" detail=%q", pe.Title, pe.Status, host, reqID, pe.Detail)
+	} else {
+		log.Warn(logLine, pe.Title, pe.Status, host, reqID)
+	}
+
+	if !wantsHTML(r) {
+		w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+		w.WriteHeader(pe.Status)
+		var b strings.Builder
+		b.WriteString(pe.Title)
+		b.WriteByte('\n')
+		b.WriteString(pe.Summary)
+		b.WriteString("\n\nRequest ID: ")
+		b.WriteString(reqID)
+		b.WriteByte('\n')
+		_, _ = w.Write([]byte(b.String()))
+		return
+	}
+
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	w.WriteHeader(pe.Status)
+	_ = errorPageTmpl.Execute(w, errorPageView{
+		Status:    pe.Status,
+		Title:     pe.Title,
+		Summary:   pe.Summary,
+		Advice:    pe.Advice,
+		Host:      host,
+		RequestID: reqID,
+		Timestamp: time.Now().UTC().Format("2006-01-02 15:04:05 MST"),
+		Nodes:     nodeStatuses(pe.Failed),
+	})
+}
+
+// requestID returns the request's correlation ID. It reuses the one stamped by
+// the access-log middleware when present so the page and the log agree; if that
+// middleware is disabled, a fresh ID is minted (and stored back so anything
+// downstream sees the same value).
+func requestID(r *http.Request) string {
+	if ri := common.RequestInfoFrom(r.Context()); ri != nil {
+		if ri.RequestID == "" {
+			ri.RequestID = common.NewRequestID()
+		}
+		return ri.RequestID
+	}
+	return common.NewRequestID()
+}
+
+// wantsHTML reports whether the client prefers an HTML response. Browsers send
+// an Accept header containing text/html; curl (Accept: */*) and most API
+// clients do not, so they keep the plain-text body.
+func wantsHTML(r *http.Request) bool {
+	return strings.Contains(r.Header.Get("Accept"), "text/html")
+}
+
+type nodeView struct {
+	Label  string
+	Sub    string
+	State  string // "ok" | "error" | "unknown"
+	Symbol string
+}
+
+type errorPageView struct {
+	Status    int
+	Title     string
+	Summary   string
+	Advice    string
+	Host      string
+	RequestID string
+	Timestamp string
+	Nodes     []nodeView
+}
+
+// nodeStatuses renders the Browser → Proxy → Agent strip: nodes before the
+// failed one are healthy, the failed one is in error, anything after is unknown.
+func nodeStatuses(failed string) []nodeView {
+	order := []struct{ id, label, sub string }{
+		{nodeClient, "Browser", "You"},
+		{nodeProxy, "Zero Trust Proxy", "Edge"},
+		{nodeAgent, "Agent", "Origin"},
+	}
+	failedIdx := -1
+	for i, n := range order {
+		if n.id == failed {
+			failedIdx = i
+			break
+		}
+	}
+	out := make([]nodeView, 0, len(order))
+	for i, n := range order {
+		v := nodeView{Label: n.label, Sub: n.sub}
+		switch {
+		case failedIdx == -1 || i < failedIdx:
+			v.State, v.Symbol = "ok", "✓"
+		case i == failedIdx:
+			v.State, v.Symbol = "error", "✕"
+		default:
+			v.State, v.Symbol = "unknown", "?"
+		}
+		out = append(out, v)
+	}
+	return out
+}
+
+// errorPageTmpl is fully self-contained (inline CSS, no external assets): when
+// the origin is down we cannot rely on fetching a stylesheet. html/template
+// auto-escapes all interpolated values, which matters because Host and Detail
+// are attacker-influenced.
+var errorPageTmpl = template.Must(template.New("errorpage").Parse(`<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta name="robots" content="noindex, nofollow">
+<title>{{.Status}} · {{.Title}}</title>
+<style>
+  :root { color-scheme: light dark; }
+  * { box-sizing: border-box; }
+  body {
+    margin: 0; min-height: 100vh;
+    font: 16px/1.5 -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+    color: #1d2430; background: #f5f6f8;
+    display: flex; align-items: flex-start; justify-content: center;
+  }
+  @media (prefers-color-scheme: dark) {
+    body { background: #16181d; }
+    .card { background: #1e2127; border-color: #2c313a; color: #e6e8eb; }
+    .nodes { background: #181b20; border-color: #2c313a; }
+    .detail { background: #14171b; border-color: #2c313a; color: #aab2bd; }
+    .foot { color: #8a929e; border-color: #2c313a; }
+    .sub { color: #8a929e; }
+  }
+  .wrap { width: 100%; max-width: 760px; padding: 48px 20px; }
+  /* The card sets its own foreground colour alongside its background so the
+     two always theme together — never light text on a light card. */
+  .card {
+    background: #fff; color: #1d2430; border: 1px solid #e3e6ea; border-radius: 12px;
+    padding: 40px; box-shadow: 0 1px 2px rgba(0,0,0,.04);
+  }
+  .code { font-size: 13px; letter-spacing: .12em; text-transform: uppercase; color: #f0843a; font-weight: 700; }
+  h1 { margin: 6px 0 10px; font-size: 28px; line-height: 1.2; }
+  .summary { margin: 0 0 8px; font-size: 17px; }
+  .nodes {
+    display: flex; align-items: stretch; gap: 0; margin: 28px 0;
+    background: #fafbfc; border: 1px solid #e3e6ea; border-radius: 10px; overflow: hidden;
+  }
+  .node { flex: 1; text-align: center; padding: 22px 8px; position: relative; }
+  .node + .node::before {
+    content: ""; position: absolute; left: 0; top: 50%; width: 1px; height: 40px;
+    background: #e3e6ea; transform: translateY(-50%);
+  }
+  .dot { width: 36px; height: 36px; border-radius: 50%; margin: 0 auto 10px;
+    display: flex; align-items: center; justify-content: center; font-weight: 700; color: #fff; }
+  .ok .dot { background: #2eb872; }
+  .error .dot { background: #e2453c; }
+  .unknown .dot { background: #9aa3af; }
+  .node .label { font-weight: 600; font-size: 14px; }
+  .sub { color: #6b7280; font-size: 12px; }
+  .state { font-size: 12px; margin-top: 4px; font-weight: 600; }
+  .ok .state { color: #2eb872; }
+  .error .state { color: #e2453c; }
+  .unknown .state { color: #9aa3af; }
+  .advice { margin: 18px 0 0; }
+  .advice h2 { font-size: 14px; text-transform: uppercase; letter-spacing: .06em; color: #6b7280; margin: 0 0 6px; }
+  .foot {
+    margin-top: 28px; padding-top: 16px; border-top: 1px solid #e3e6ea;
+    display: flex; flex-wrap: wrap; gap: 6px 20px; color: #6b7280; font-size: 13px;
+  }
+  .foot code { font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; }
+</style>
+</head>
+<body>
+  <div class="wrap">
+    <div class="card">
+      <div class="code">Error {{.Status}}</div>
+      <h1>{{.Title}}</h1>
+      <p class="summary">{{.Summary}}</p>
+
+      <div class="nodes">
+        {{range .Nodes}}
+        <div class="node {{.State}}">
+          <div class="dot">{{.Symbol}}</div>
+          <div class="label">{{.Label}}</div>
+          <div class="sub">{{.Sub}}</div>
+          <div class="state">{{if eq .State "ok"}}Working{{else if eq .State "error"}}Error{{else}}Unknown{{end}}</div>
+        </div>
+        {{end}}
+      </div>
+
+      {{if .Advice}}
+      <div class="advice">
+        <h2>What can I do?</h2>
+        <p>{{.Advice}}</p>
+      </div>
+      {{end}}
+
+      <div class="foot">
+        <span>Host: <code>{{.Host}}</code></span>
+        <span>Request ID: <code>{{.RequestID}}</code></span>
+        <span>{{.Timestamp}}</span>
+      </div>
+    </div>
+  </div>
+</body>
+</html>`))

--- a/modules/ztrouter/errorpage.go
+++ b/modules/ztrouter/errorpage.go
@@ -1,8 +1,10 @@
 package ztrouter
 
 import (
+	"bytes"
 	"html/template"
 	"net/http"
+	"strconv"
 	"strings"
 	"time"
 
@@ -56,22 +58,17 @@ func writeProxyError(w http.ResponseWriter, r *http.Request, pe proxyError) {
 	}
 
 	if !wantsHTML(r) {
-		w.Header().Set("Content-Type", "text/plain; charset=utf-8")
-		w.WriteHeader(pe.Status)
-		var b strings.Builder
-		b.WriteString(pe.Title)
-		b.WriteByte('\n')
-		b.WriteString(pe.Summary)
-		b.WriteString("\n\nRequest ID: ")
-		b.WriteString(reqID)
-		b.WriteByte('\n')
-		_, _ = w.Write([]byte(b.String()))
+		writePlainError(w, pe, reqID)
 		return
 	}
 
-	w.Header().Set("Content-Type", "text/html; charset=utf-8")
-	w.WriteHeader(pe.Status)
-	_ = errorPageTmpl.Execute(w, errorPageView{
+	// Render into a buffer first. A template-execution error is then caught
+	// before the status line or any bytes are committed, so it can be logged
+	// and we can fall back to plain text — rather than streaming directly to
+	// the client and leaving a half-written, silently corrupt HTML document on
+	// failure.
+	var buf bytes.Buffer
+	if err := errorPageTmpl.Execute(&buf, errorPageView{
 		Status:    pe.Status,
 		Title:     pe.Title,
 		Summary:   pe.Summary,
@@ -80,7 +77,34 @@ func writeProxyError(w http.ResponseWriter, r *http.Request, pe proxyError) {
 		RequestID: reqID,
 		Timestamp: time.Now().UTC().Format("2006-01-02 15:04:05 MST"),
 		Nodes:     nodeStatuses(pe.Failed),
-	})
+	}); err != nil {
+		log.Error("ztrouter: render error page failed id=%s: %v", reqID, err)
+		writePlainError(w, pe, reqID)
+		return
+	}
+
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	w.WriteHeader(pe.Status)
+	if _, err := buf.WriteTo(w); err != nil && !isClientGone(err) {
+		log.Error("ztrouter: write error page failed id=%s: %v", reqID, err)
+	}
+}
+
+// writePlainError writes the compact text/plain form of a proxy error. It is
+// both the response for non-HTML clients and the fallback when HTML rendering
+// fails. Shared headers (X-Request-Id, Vary, Cache-Control) are already set by
+// writeProxyError before this is called.
+func writePlainError(w http.ResponseWriter, pe proxyError, reqID string) {
+	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+	w.WriteHeader(pe.Status)
+	var b strings.Builder
+	b.WriteString(pe.Title)
+	b.WriteByte('\n')
+	b.WriteString(pe.Summary)
+	b.WriteString("\n\nRequest ID: ")
+	b.WriteString(reqID)
+	b.WriteByte('\n')
+	_, _ = w.Write([]byte(b.String()))
 }
 
 // requestID returns the request's correlation ID. It reuses the one stamped by
@@ -97,11 +121,38 @@ func requestID(r *http.Request) string {
 	return common.NewRequestID()
 }
 
-// wantsHTML reports whether the client prefers an HTML response. Browsers send
-// an Accept header containing text/html; curl (Accept: */*) and most API
-// clients do not, so they keep the plain-text body.
+// wantsHTML reports whether the client will accept an HTML response, honoring
+// RFC 7231 content negotiation. Browsers list text/html with a positive
+// quality; curl (Accept: */*) and most API clients don't list text/html at all
+// and keep the plain-text body. A client that sends "text/html;q=0" to
+// explicitly opt out is respected and also gets plain text. Note that "*/*"
+// alone does not select HTML — only an explicit, non-zero-quality text/html
+// does — so API clients aren't surprised with markup.
 func wantsHTML(r *http.Request) bool {
-	return strings.Contains(r.Header.Get("Accept"), "text/html")
+	for _, part := range strings.Split(r.Header.Get("Accept"), ",") {
+		if media, q := parseAcceptPart(part); media == "text/html" && q > 0 {
+			return true
+		}
+	}
+	return false
+}
+
+// parseAcceptPart splits one comma-separated Accept entry into its lowercased
+// media type and quality value. Quality defaults to 1.0 when no q parameter is
+// present or it fails to parse, matching the RFC 7231 default.
+func parseAcceptPart(part string) (media string, q float64) {
+	q = 1.0
+	fields := strings.Split(part, ";")
+	media = strings.ToLower(strings.TrimSpace(fields[0]))
+	for _, p := range fields[1:] {
+		p = strings.ToLower(strings.TrimSpace(p))
+		if strings.HasPrefix(p, "q=") {
+			if f, err := strconv.ParseFloat(strings.TrimSpace(p[2:]), 64); err == nil {
+				q = f
+			}
+		}
+	}
+	return media, q
 }
 
 type nodeView struct {

--- a/modules/ztrouter/errorpage_test.go
+++ b/modules/ztrouter/errorpage_test.go
@@ -1,0 +1,129 @@
+package ztrouter
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/devhatro/zero-trust-proxy/internal/common"
+)
+
+func newErrReq(accept string) *http.Request {
+	req := httptest.NewRequest(http.MethodGet, "http://shop.example.com/checkout", nil)
+	if accept != "" {
+		req.Header.Set("Accept", accept)
+	}
+	return req
+}
+
+func TestWriteProxyError_HTMLForBrowsers(t *testing.T) {
+	rr := httptest.NewRecorder()
+	req := newErrReq("text/html,application/xhtml+xml")
+	writeProxyError(rr, req, proxyError{
+		Status:  http.StatusServiceUnavailable,
+		Title:   "Agent Unreachable",
+		Summary: "No agent is connected.",
+		Failed:  nodeAgent,
+	})
+
+	if rr.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status=%d, want 503", rr.Code)
+	}
+	if ct := rr.Header().Get("Content-Type"); !strings.HasPrefix(ct, "text/html") {
+		t.Fatalf("content-type=%q, want text/html", ct)
+	}
+	body := rr.Body.String()
+	for _, want := range []string{"<!doctype html>", "Agent Unreachable", "shop.example.com", "Zero Trust Proxy"} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("html body missing %q\n%s", want, body)
+		}
+	}
+}
+
+func TestWriteProxyError_PlainTextForAPIClients(t *testing.T) {
+	rr := httptest.NewRecorder()
+	req := newErrReq("*/*") // curl default
+	writeProxyError(rr, req, proxyError{
+		Status:  http.StatusBadGateway,
+		Title:   "Agent Connection Lost",
+		Summary: "The connection dropped.",
+		Detail:  "write tcp 10.0.0.5:8443->10.0.0.9:51234: write: broken pipe",
+		Failed:  nodeAgent,
+	})
+
+	if ct := rr.Header().Get("Content-Type"); !strings.HasPrefix(ct, "text/plain") {
+		t.Fatalf("content-type=%q, want text/plain", ct)
+	}
+	body := rr.Body.String()
+	if strings.Contains(body, "<html") {
+		t.Fatalf("plain client got HTML: %s", body)
+	}
+	for _, want := range []string{"Agent Connection Lost", "Request ID:"} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("plain body missing %q\n%s", want, body)
+		}
+	}
+	// Detail is log-only: a raw error containing internal addresses must never
+	// reach the client.
+	if strings.Contains(body, "broken pipe") || strings.Contains(body, "10.0.0.5") {
+		t.Fatalf("plain body leaked Detail to client: %s", body)
+	}
+}
+
+func TestWriteProxyError_SetsRequestIDHeaderAndReusesContextID(t *testing.T) {
+	rr := httptest.NewRecorder()
+	ri := &common.RequestInfo{RequestID: "abc123def456"}
+	req := newErrReq("text/html")
+	req = req.WithContext(common.WithRequestInfo(req.Context(), ri))
+
+	writeProxyError(rr, req, proxyError{
+		Status:  http.StatusGatewayTimeout,
+		Title:   "Agent Timeout",
+		Summary: "Timed out.",
+		Failed:  nodeAgent,
+	})
+
+	if got := rr.Header().Get("X-Request-Id"); got != "abc123def456" {
+		t.Fatalf("X-Request-Id=%q, want abc123def456", got)
+	}
+	if cc := rr.Header().Get("Cache-Control"); cc != "no-store" {
+		t.Fatalf("Cache-Control=%q, want no-store", cc)
+	}
+	if !strings.Contains(rr.Body.String(), "abc123def456") {
+		t.Fatal("page should display the request ID")
+	}
+}
+
+func TestNodeStatuses_AgentFailure(t *testing.T) {
+	nodes := nodeStatuses(nodeAgent)
+	if len(nodes) != 3 {
+		t.Fatalf("want 3 nodes, got %d", len(nodes))
+	}
+	if nodes[0].State != "ok" || nodes[1].State != "ok" || nodes[2].State != "error" {
+		t.Fatalf("agent-failure states = %q/%q/%q, want ok/ok/error",
+			nodes[0].State, nodes[1].State, nodes[2].State)
+	}
+}
+
+func TestNodeStatuses_ClientFailureMarksLaterUnknown(t *testing.T) {
+	nodes := nodeStatuses(nodeClient)
+	if nodes[0].State != "error" || nodes[1].State != "unknown" || nodes[2].State != "unknown" {
+		t.Fatalf("client-failure states = %q/%q/%q, want error/unknown/unknown",
+			nodes[0].State, nodes[1].State, nodes[2].State)
+	}
+}
+
+func TestWantsHTML(t *testing.T) {
+	cases := map[string]bool{
+		"text/html,application/xhtml+xml,application/xml;q=0.9": true,
+		"*/*":              false,
+		"application/json": false,
+		"":                 false,
+	}
+	for accept, want := range cases {
+		if got := wantsHTML(newErrReq(accept)); got != want {
+			t.Errorf("wantsHTML(%q)=%v, want %v", accept, got, want)
+		}
+	}
+}

--- a/modules/ztrouter/errorpage_test.go
+++ b/modules/ztrouter/errorpage_test.go
@@ -1,6 +1,7 @@
 package ztrouter
 
 import (
+	"html/template"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -117,13 +118,55 @@ func TestNodeStatuses_ClientFailureMarksLaterUnknown(t *testing.T) {
 func TestWantsHTML(t *testing.T) {
 	cases := map[string]bool{
 		"text/html,application/xhtml+xml,application/xml;q=0.9": true,
-		"*/*":              false,
-		"application/json": false,
-		"":                 false,
+		"text/html;q=0.9":                   true,
+		"*/*":                               false,
+		"application/json":                  false,
+		"":                                  false,
+		"text/html;q=0":                     false, // explicit opt-out
+		"text/html;q=0, application/json":   false, // opt out, prefer JSON
+		"text/html ; q=0.0":                 false, // spacing + zero
+		"application/json, text/html;q=0":   false,
+		"application/json, text/html;q=0.5": true, // explicitly acceptable
 	}
 	for accept, want := range cases {
 		if got := wantsHTML(newErrReq(accept)); got != want {
 			t.Errorf("wantsHTML(%q)=%v, want %v", accept, got, want)
 		}
+	}
+}
+
+// TestWriteProxyError_RenderFailureFallsBackToPlain verifies that when the
+// HTML template fails to execute, the client gets a plain-text body (with the
+// correct status) instead of a half-written HTML document.
+func TestWriteProxyError_RenderFailureFallsBackToPlain(t *testing.T) {
+	orig := errorPageTmpl
+	// A template referencing a missing field with a strict option errors at
+	// execution time, forcing the render-failure branch.
+	errorPageTmpl = template.Must(
+		template.New("boom").Option("missingkey=error").Parse(`{{.DoesNotExist}}`),
+	)
+	t.Cleanup(func() { errorPageTmpl = orig })
+
+	rr := httptest.NewRecorder()
+	req := newErrReq("text/html")
+	writeProxyError(rr, req, proxyError{
+		Status:  http.StatusBadGateway,
+		Title:   "Agent Error",
+		Summary: "boom",
+		Failed:  nodeAgent,
+	})
+
+	if rr.Code != http.StatusBadGateway {
+		t.Fatalf("status=%d, want 502", rr.Code)
+	}
+	if ct := rr.Header().Get("Content-Type"); !strings.HasPrefix(ct, "text/plain") {
+		t.Fatalf("content-type=%q, want text/plain fallback", ct)
+	}
+	body := rr.Body.String()
+	if strings.Contains(body, "<") {
+		t.Fatalf("fallback should be plain text, got markup: %q", body)
+	}
+	if !strings.Contains(body, "Agent Error") || !strings.Contains(body, "Request ID:") {
+		t.Fatalf("fallback body missing expected fields: %q", body)
 	}
 }

--- a/modules/ztrouter/handler.go
+++ b/modules/ztrouter/handler.go
@@ -50,8 +50,13 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	agent, svc, ok := h.app.LookupService(host)
 	if !ok {
-		log.Debug("ztrouter: no agent for host=%s", host)
-		http.Error(w, "No agent for host "+host, http.StatusServiceUnavailable)
+		writeProxyError(w, r, proxyError{
+			Status:  http.StatusServiceUnavailable,
+			Title:   "Agent Unreachable",
+			Summary: "No agent is currently connected to serve this hostname.",
+			Advice:  "The service may be starting up or temporarily offline. Wait a moment and retry; if it persists, confirm the agent for this host is running and registered.",
+			Failed:  nodeAgent,
+		})
 		return
 	}
 	if ri := common.RequestInfoFrom(r.Context()); ri != nil {
@@ -98,8 +103,14 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			msgID, r.Body, msgID, r.ContentLength,
 			r.Method, requestURL(r), headers, agent,
 		); err != nil {
-			log.Error("ztrouter: upload stream to agent %s: %v", agent.ID, err)
-			http.Error(w, "Failed to stream upload: "+err.Error(), http.StatusBadGateway)
+			writeProxyError(w, r, proxyError{
+				Status:  http.StatusBadGateway,
+				Title:   "Upload Failed",
+				Summary: "The proxy could not deliver your upload to the agent.",
+				Advice:  "The connection to the agent was interrupted. Retry the upload; if it keeps failing, check the agent's connectivity.",
+				Detail:  err.Error(),
+				Failed:  nodeAgent,
+			})
 			return
 		}
 	} else {
@@ -124,8 +135,14 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			},
 		}
 		if err := agent.SendMessage(httpMsg); err != nil {
-			log.Error("ztrouter: send to agent %s: %v", agent.ID, err)
-			http.Error(w, "Failed to forward request", http.StatusBadGateway)
+			writeProxyError(w, r, proxyError{
+				Status:  http.StatusBadGateway,
+				Title:   "Agent Connection Lost",
+				Summary: "The connection to the agent dropped before your request could be delivered.",
+				Advice:  "The agent may have just disconnected. Retry shortly; if the error continues, verify the agent is connected to the proxy.",
+				Detail:  err.Error(),
+				Failed:  nodeAgent,
+			})
 			return
 		}
 	}
@@ -148,11 +165,17 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			}
 			return
 		}
-		writeAgentResponse(w, resp)
+		writeAgentResponse(w, r, resp)
 	case <-r.Context().Done():
 		return
 	case <-time.After(requestTimeout):
-		http.Error(w, "Agent response timeout", http.StatusGatewayTimeout)
+		writeProxyError(w, r, proxyError{
+			Status:  http.StatusGatewayTimeout,
+			Title:   "Agent Timeout",
+			Summary: "The agent did not respond in time.",
+			Advice:  "The backend may be slow or overloaded. Retry in a moment; if timeouts persist, check the upstream service behind the agent.",
+			Failed:  nodeAgent,
+		})
 	}
 }
 
@@ -196,13 +219,26 @@ func requestURL(r *http.Request) string {
 	return r.URL.EscapedPath() + "?" + r.URL.RawQuery
 }
 
-func writeAgentResponse(w http.ResponseWriter, resp *common.Message) {
+func writeAgentResponse(w http.ResponseWriter, r *http.Request, resp *common.Message) {
 	if resp.Error != "" {
-		http.Error(w, resp.Error, http.StatusBadGateway)
+		writeProxyError(w, r, proxyError{
+			Status:  http.StatusBadGateway,
+			Title:   "Agent Error",
+			Summary: "The agent reported an error while handling your request.",
+			Advice:  "This usually means the upstream service behind the agent failed. Retry, or check the backend the agent proxies to.",
+			Detail:  resp.Error,
+			Failed:  nodeAgent,
+		})
 		return
 	}
 	if resp.HTTP == nil {
-		http.Error(w, "Invalid response from agent", http.StatusBadGateway)
+		writeProxyError(w, r, proxyError{
+			Status:  http.StatusBadGateway,
+			Title:   "Invalid Agent Response",
+			Summary: "The agent returned a malformed response.",
+			Advice:  "This is unexpected. Retry the request; if it continues, inspect the agent logs.",
+			Failed:  nodeAgent,
+		})
 		return
 	}
 

--- a/modules/ztrouter/handler_test.go
+++ b/modules/ztrouter/handler_test.go
@@ -303,18 +303,25 @@ func TestHandler_ContextCancelled(t *testing.T) {
 
 func TestWriteAgentResponse_ErrorField(t *testing.T) {
 	rr := httptest.NewRecorder()
-	writeAgentResponse(rr, &common.Message{Error: "backend unavailable"})
+	req := httptest.NewRequest(http.MethodGet, "http://x.example.com/", nil)
+	writeAgentResponse(rr, req, &common.Message{Error: "backend unavailable"})
 	if rr.Code != http.StatusBadGateway {
 		t.Fatalf("status=%d, want 502", rr.Code)
 	}
-	if !strings.Contains(rr.Body.String(), "backend unavailable") {
-		t.Fatalf("body=%q, want error message", rr.Body.String())
+	body := rr.Body.String()
+	if !strings.Contains(body, "Agent Error") {
+		t.Fatalf("body=%q, want branded title", body)
+	}
+	// The raw agent error is log-only and must not be echoed to the client.
+	if strings.Contains(body, "backend unavailable") {
+		t.Fatalf("body leaked raw agent error: %q", body)
 	}
 }
 
 func TestWriteAgentResponse_NilHTTP(t *testing.T) {
 	rr := httptest.NewRecorder()
-	writeAgentResponse(rr, &common.Message{})
+	req := httptest.NewRequest(http.MethodGet, "http://x.example.com/", nil)
+	writeAgentResponse(rr, req, &common.Message{})
 	if rr.Code != http.StatusBadGateway {
 		t.Fatalf("status=%d, want 502", rr.Code)
 	}
@@ -322,7 +329,8 @@ func TestWriteAgentResponse_NilHTTP(t *testing.T) {
 
 func TestWriteAgentResponse_ZeroStatusDefaultsTo200(t *testing.T) {
 	rr := httptest.NewRecorder()
-	writeAgentResponse(rr, &common.Message{
+	req := httptest.NewRequest(http.MethodGet, "http://x.example.com/", nil)
+	writeAgentResponse(rr, req, &common.Message{
 		HTTP: &common.HTTPData{
 			StatusCode: 0,
 			Headers:    map[string][]string{"X-Test": {"yes"}},


### PR DESCRIPTION
## Summary
- Replace bare plain-text `http.Error` responses on agent-failure paths (no agent for host, send/upload failure, response timeout, agent-reported error) with a Cloudflare-style HTML status page showing a **Browser → Proxy → Agent** health strip, a request ID, and a timestamp.
- Content-negotiate: browsers (`Accept: text/html`) get the HTML page; API/curl clients keep a compact plain-text body. Self-contained inline CSS (no external assets when the origin is down), `Cache-Control: no-store`, `Vary: Accept`, and `html/template` auto-escaping of the attacker-influenced `Host`.
- Add a per-request ID ("Ray ID") on `common.RequestInfo`, generated in the access-log middleware, surfaced via the page, the `X-Request-Id` header, and the access-log JSON (`request_id`).
- Raw error detail is **logged with the request ID but never sent to the client**, so internal addresses aren't leaked.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` (all packages pass)
- [x] New `errorpage_test.go`: HTML-vs-plain content negotiation, status codes, `X-Request-Id`/`Cache-Control` headers, node-status strip, and assertions that raw detail/internal addresses never reach the client
- [x] Rendered light + dark sample pages via headless Chrome
<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Replace generic error responses with branded HTML error pages displaying request correlation IDs and request status for unreachable agents in ztrouter.

Main changes:
- Added RequestID field to RequestInfo struct and NewRequestID() function generating 16-char hex identifiers for request correlation
- Created errorpage.go module with writeProxyError() rendering branded HTML/plain-text error pages based on Accept header negotiation
- Integrated error page rendering into handler.go for agent unavailability, timeout, and communication failures with user-friendly guidance

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added per-request IDs to responses and access logs for easier troubleshooting.
  * Added branded error pages that show a friendly HTML page for browsers and plain text for API clients.

* **Bug Fixes**
  * Standardized error handling for gateway, upload, timeout, and upstream response failures.
  * Prevented sensitive internal error details from being exposed in client-facing responses.
  * Added cache prevention and request ID headers to error responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->