### PR TITLE
chore(ci): bump workflow action versions

### DIFF
--- a/.github/workflows/release-pipeline.yml
+++ b/.github/workflows/release-pipeline.yml
@@ -34,7 +34,7 @@ jobs:
           ./scripts/build.sh
 
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: build-artifacts
           path: bin/
@@ -46,8 +46,8 @@ jobs:
     needs: build
     strategy:
       matrix:
-        component: [ server, agent ]
-        platform: [ amd64, arm64 ]
+        component: [server, agent]
+        platform: [amd64, arm64]
         include:
           - component: server
             dockerfile: ./cmd/zero-trust-proxy/Dockerfile
@@ -63,30 +63,32 @@ jobs:
           '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
 
       - name: Download Build Artifacts
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@v8
         with:
           name: build-artifacts
           path: bin/
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build and push ${{ matrix.component }} image for linux/${{ matrix.platform
+      - name:
+          Build and push ${{ matrix.component }} image for linux/${{ matrix.platform
           }}
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: ${{ matrix.dockerfile }}
           platforms: linux/${{ matrix.platform }}
           push: true
-          tags: ghcr.io/${{ env.REPO_OWNER_LOWER }}/zero-trust-proxy-${{ matrix.component
+          tags:
+            ghcr.io/${{ env.REPO_OWNER_LOWER }}/zero-trust-proxy-${{ matrix.component
             }}:${{ github.ref_name }}-linux-${{ matrix.platform }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
@@ -101,17 +103,17 @@ jobs:
     needs: docker-build
     strategy:
       matrix:
-        component: [ server, agent ]
+        component: [server, agent]
     steps:
       - name: Set lowercase repo owner
         run: echo "REPO_OWNER_LOWER=$(echo ${{ github.repository_owner }} | tr
           '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
@@ -127,10 +129,10 @@ jobs:
   release:
     name: Create Release
     runs-on: ubuntu-latest
-    needs: [ build, create-manifests ]
+    needs: [build, create-manifests]
     steps:
       - name: Download Artifacts
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@v8
         with:
           name: build-artifacts
           path: bin/

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -51,7 +51,7 @@ jobs:
         run: ./scripts/build.sh
 
       - name: Upload Test Artifacts
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: test-build-artifacts
           path: bin/


### PR DESCRIPTION
## Summary
- Bump GitHub Actions to current majors in `release-pipeline.yml` and `test-build.yml`: `upload-artifact` v5→v7, `download-artifact` v6→v8, `setup-buildx-action` v3→v4, `login-action` v3→v4, `build-push-action` v6→v7.
- Normalize YAML flow-sequence spacing (e.g. `[ server, agent ]` → `[server, agent]`).

## Test plan
- [ ] CI pipeline runs green on this PR (build + test-build workflows)
- [ ] Release pipeline succeeds on next tag (artifact upload/download + multi-arch image build/push)
<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Update GitHub Actions workflow versions to latest releases for improved security, performance, and compatibility across CI/CD pipeline.

Main changes:
- Bumped upload/download artifact actions from v5-v6 to v7-v8, and docker actions from v3 to v4, build-push from v6 to v7
- Reformatted matrix strategy syntax for docker-build and create-manifests jobs for consistency
- Added explicit job dependency `needs: [build, create-manifests]` to release job for proper execution order

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
