### PR TITLE
fix(server): serve ACME cert for known hosts when the agent is down

### DIFF
--- a/internal/server/knownhosts.go
+++ b/internal/server/knownhosts.go
@@ -1,0 +1,109 @@
+package server
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+)
+
+// knownHosts is the persistent set of hostnames that an agent has registered
+// at some point. It exists to decouple TLS certificate serving from a live
+// agent connection: in ACME mode the HostPolicy gates cert issuance, and
+// without this set a restart with no agents connected (or a stopped agent)
+// would refuse to serve even a cached certificate — failing the TLS handshake
+// with ERR_SSL_PROTOCOL_ERROR before any HTTP error page could be rendered.
+//
+// By remembering hosts that were genuinely registered, the handshake can
+// complete from the ACME cache while the agent is down, letting ztrouter
+// return the branded "Agent Unreachable" page instead. Hosts are only ever
+// added when an agent is actually serving them, so this never broadens cert
+// issuance to arbitrary SNI values.
+//
+// The set is persisted as a sorted JSON array via atomic temp-file rename.
+// Persistence failures are non-fatal (logged): the in-memory set still works
+// for the life of the process.
+type knownHosts struct {
+	mu   sync.Mutex
+	set  map[string]struct{}
+	path string // empty disables persistence (used in tests)
+}
+
+// loadKnownHosts reads the persisted set from path. A missing or unparseable
+// file yields an empty set — this is expected on first run and must not fail
+// startup.
+func loadKnownHosts(path string) *knownHosts {
+	kh := &knownHosts{set: make(map[string]struct{}), path: path}
+	if path == "" {
+		return kh
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return kh // missing file on first run is normal
+	}
+	var hosts []string
+	if err := json.Unmarshal(data, &hosts); err != nil {
+		log.Warn("known-hosts: ignoring unparseable %s: %v", path, err)
+		return kh
+	}
+	for _, h := range hosts {
+		if h = strings.ToLower(strings.TrimSpace(h)); h != "" {
+			kh.set[h] = struct{}{}
+		}
+	}
+	return kh
+}
+
+// has reports whether host is in the set (case-insensitive).
+func (kh *knownHosts) has(host string) bool {
+	host = strings.ToLower(host)
+	kh.mu.Lock()
+	defer kh.mu.Unlock()
+	_, ok := kh.set[host]
+	return ok
+}
+
+// add records host and persists the set if it changed. It is a no-op when host
+// is already present, so the common (already-known) path does no disk I/O.
+func (kh *knownHosts) add(host string) {
+	host = strings.ToLower(host)
+	kh.mu.Lock()
+	defer kh.mu.Unlock()
+	if _, ok := kh.set[host]; ok {
+		return
+	}
+	kh.set[host] = struct{}{}
+	kh.persistLocked()
+}
+
+// persistLocked writes the set to disk atomically. Caller holds kh.mu.
+func (kh *knownHosts) persistLocked() {
+	if kh.path == "" {
+		return
+	}
+	hosts := make([]string, 0, len(kh.set))
+	for h := range kh.set {
+		hosts = append(hosts, h)
+	}
+	sort.Strings(hosts)
+
+	data, err := json.MarshalIndent(hosts, "", "  ")
+	if err != nil {
+		log.Error("known-hosts: marshal failed: %v", err)
+		return
+	}
+	if err := os.MkdirAll(filepath.Dir(kh.path), 0o700); err != nil {
+		log.Error("known-hosts: mkdir %s: %v", filepath.Dir(kh.path), err)
+		return
+	}
+	tmp := kh.path + ".tmp"
+	if err := os.WriteFile(tmp, data, 0o600); err != nil {
+		log.Error("known-hosts: write %s: %v", tmp, err)
+		return
+	}
+	if err := os.Rename(tmp, kh.path); err != nil {
+		log.Error("known-hosts: rename %s -> %s: %v", tmp, kh.path, err)
+	}
+}

--- a/internal/server/knownhosts_test.go
+++ b/internal/server/knownhosts_test.go
@@ -1,0 +1,72 @@
+package server
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestKnownHosts_AddHasPersistRoundTrip(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "sub", "known_hosts.json")
+
+	kh := loadKnownHosts(path)
+	if kh.has("a.example") {
+		t.Fatal("fresh set should be empty")
+	}
+
+	kh.add("A.Example") // mixed case — stored lowercased
+	kh.add("b.example")
+	kh.add("a.example") // duplicate — no-op
+
+	if !kh.has("a.example") || !kh.has("b.example") {
+		t.Fatal("added hosts not found")
+	}
+	if !kh.has("A.EXAMPLE") {
+		t.Fatal("lookup should be case-insensitive")
+	}
+
+	// The file (and its parent dir) should have been created.
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("persisted file missing: %v", err)
+	}
+
+	// A reload from disk sees the same hosts.
+	reloaded := loadKnownHosts(path)
+	if !reloaded.has("a.example") || !reloaded.has("b.example") {
+		t.Fatal("reloaded set missing persisted hosts")
+	}
+}
+
+func TestKnownHosts_MissingFileIsEmptyNotError(t *testing.T) {
+	kh := loadKnownHosts(filepath.Join(t.TempDir(), "does-not-exist.json"))
+	if kh == nil {
+		t.Fatal("loadKnownHosts returned nil")
+	}
+	if kh.has("anything.example") {
+		t.Fatal("missing file should yield empty set")
+	}
+}
+
+func TestKnownHosts_UnparseableFileIgnored(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "known_hosts.json")
+	if err := os.WriteFile(path, []byte("{not json"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	kh := loadKnownHosts(path) // must not panic or fail
+	if kh.has("x.example") {
+		t.Fatal("garbage file should yield empty set")
+	}
+	// And it should still be usable afterwards.
+	kh.add("x.example")
+	if !kh.has("x.example") {
+		t.Fatal("add after ignoring garbage file failed")
+	}
+}
+
+func TestKnownHosts_EmptyPathDisablesPersistence(t *testing.T) {
+	kh := loadKnownHosts("")
+	kh.add("x.example") // must not panic with empty path
+	if !kh.has("x.example") {
+		t.Fatal("in-memory add should still work with persistence disabled")
+	}
+}

--- a/internal/server/tls.go
+++ b/internal/server/tls.go
@@ -5,6 +5,7 @@ import (
 	"crypto/tls"
 	"fmt"
 	"net/http"
+	"path/filepath"
 	"strings"
 	"sync/atomic"
 
@@ -31,10 +32,10 @@ type certEntry struct {
 // HTTPS listener plus optional state for ACME and reload.
 type tlsBundle struct {
 	tlsConfig   *tls.Config
-	acmeHandler http.Handler        // mount at :80 for HTTP-01 challenges (acme mode only)
-	acme        *autocert.Manager   // nil unless mode == acme
+	acmeHandler http.Handler      // mount at :80 for HTTP-01 challenges (acme mode only)
+	acme        *autocert.Manager // nil unless mode == acme
 	mode        serverconfig.TLSMode
-	manualCert  *certEntry          // mode == manual
+	manualCert  *certEntry            // mode == manual
 	sniCerts    map[string]*certEntry // mode == sni; key is lowercase hostname
 }
 
@@ -124,14 +125,21 @@ func buildTLSConfig(cfg serverconfig.TLSConfig, lookup HostLookup) (*tlsBundle, 
 		}, nil
 
 	case serverconfig.TLSModeACME:
+		// Remember hosts that have been served so a certificate can still be
+		// obtained/served while the agent is down (e.g. after a restart with no
+		// agents connected). Without this, HostPolicy would reject every host
+		// and the TLS handshake would fail before ztrouter could render the
+		// "Agent Unreachable" page. See knownHosts for the rationale.
+		known := loadKnownHosts(filepath.Join(cfg.ACME.StorageDir, "known_hosts.json"))
 		hostPolicy := autocert.HostPolicy(func(_ context.Context, host string) error {
-			if lookup == nil {
-				return fmt.Errorf("no host lookup configured")
+			if lookup != nil && lookup(host) {
+				known.add(host) // currently served — record it for future restarts
+				return nil
 			}
-			if !lookup(host) {
-				return fmt.Errorf("host %q not registered with any agent", host)
+			if known.has(host) {
+				return nil // previously served — allow cached/re-issued cert so the page can load
 			}
-			return nil
+			return fmt.Errorf("host %q not registered with any agent", host)
 		})
 		m := &autocert.Manager{
 			Cache:      autocert.DirCache(cfg.ACME.StorageDir),

--- a/internal/server/tls_test.go
+++ b/internal/server/tls_test.go
@@ -102,6 +102,42 @@ func TestBuildTLS_ACME_HostPolicyConsultsLookup(t *testing.T) {
 	}
 }
 
+// TestBuildTLS_ACME_KnownHostSurvivesAgentDown verifies that a host served
+// while its agent was connected stays allowed by HostPolicy after the agent
+// goes away (simulated by a fresh bundle built from the same storage dir with
+// a lookup that now returns false). This is what lets a cached cert be served
+// on restart so the branded error page can render instead of ERR_SSL.
+func TestBuildTLS_ACME_KnownHostSurvivesAgentDown(t *testing.T) {
+	dir := t.TempDir()
+	mkACME := func(lookup HostLookup) *tlsBundle {
+		b, err := buildTLSConfig(serverconfig.TLSConfig{
+			Mode: serverconfig.TLSModeACME,
+			ACME: &serverconfig.ACMEConfig{StorageDir: dir, Email: "ops@example.com"},
+		}, lookup)
+		if err != nil {
+			t.Fatalf("buildTLSConfig: %v", err)
+		}
+		return b
+	}
+
+	// Agent connected: host passes and is recorded.
+	up := mkACME(func(host string) bool { return host == "nas.example" })
+	if err := up.acme.HostPolicy(t.Context(), "nas.example"); err != nil {
+		t.Fatalf("HostPolicy(nas.example) while up = %v, want nil", err)
+	}
+
+	// Simulate restart with NO agents: lookup returns false for everything.
+	down := mkACME(func(string) bool { return false })
+	if err := down.acme.HostPolicy(t.Context(), "nas.example"); err != nil {
+		t.Fatalf("HostPolicy(nas.example) after restart/agent-down = %v, want nil (known host)", err)
+	}
+	// A host that was never served must still be rejected — issuance is not
+	// broadened to arbitrary SNI.
+	if err := down.acme.HostPolicy(t.Context(), "never-seen.example"); err == nil {
+		t.Fatal("HostPolicy(never-seen.example) = nil, want error")
+	}
+}
+
 // writeKeyPair generates a short-lived self-signed cert/key and writes
 // them as PEM files in a temp directory. Returns paths.
 func writeKeyPair(t *testing.T, cn string) (certPath, keyPath string) {


### PR DESCRIPTION
## Summary
- **Problem:** In ACME mode, the cert `HostPolicy` only allowed a host with a *live* agent registration (`tls.go` → `lookupHost` → `LookupAgent`). On a server restart with no agents connected — or whenever the agent is stopped — autocert refused to serve even a cached cert, so the **TLS handshake failed with `ERR_SSL_PROTOCOL_ERROR`** before `ztrouter` could render the branded "Agent Unreachable" page. The friendly error page is at the HTTP layer, which is unreachable over a failed handshake.
- **Fix:** Persist the set of hostnames an agent has registered (`known_hosts.json` in the ACME storage dir). `HostPolicy` now allows a host that is **currently registered OR previously known**, so a valid cached cert is served while the agent is down and the HTML error page loads. Brand-new, never-served SNI values are still rejected — cert issuance is not broadened to arbitrary hostnames.
- Hosts are recorded lazily, exactly when `HostPolicy` passes for a live agent; persistence is atomic (temp-file + rename) and non-fatal on failure.

## Scope / notes
- Only affects `acme` mode. `manual`/`sni`/`none` already serve certs independent of agents, so they show the branded page on agent-down once the server binary is up to date.
- Does not prune hosts whose service is permanently removed (the cert keeps serving and the page renders "Agent Unreachable"); pruning can be added later if desired.

## Test plan
- [x] `go build ./...`, `go vet ./...`
- [x] `go test ./...` (518 pass) + `go test -race` on the new logic
- [x] `knownhosts_test.go`: add/has/persist round-trip, case-insensitivity, missing/garbage file tolerated, empty-path disables persistence
- [x] `TestBuildTLS_ACME_KnownHostSurvivesAgentDown`: host served while up stays allowed after a simulated restart with no agents; never-seen host still rejected
- [ ] Manual: restart server with agent stopped → browser loads the branded "Agent Unreachable" page (not `ERR_SSL_PROTOCOL_ERROR`)
<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Enable ACME certificate serving for previously-registered hosts when agent connections are unavailable, preventing TLS handshake failures.

Main changes:
- New knownHosts module persists registered hostnames to JSON, enabling cert cache lookup during agent downtime
- Updated ACME HostPolicy to check both active agent lookup and persisted known hosts set
- Added comprehensive tests verifying persistent host tracking and cert availability after agent restart

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * TLS/ACME now remembers previously served hostnames, allowing certificates to keep working even if a host is temporarily unavailable.
  * Known hostnames are stored case-insensitively and can be restored after a restart.

* **Bug Fixes**
  * Missing or unreadable host cache files no longer block startup.
  * Host cache updates are saved safely, with failed saves handled without interrupting service.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->