### PR TITLE
fix(ztrouter): never drop streaming response chunks; abort truncated streams

### DIFF
--- a/modules/ztrouter/download.go
+++ b/modules/ztrouter/download.go
@@ -76,6 +76,12 @@ func (h *Handler) streamDownloadFlush(
 	var chunkIdx int
 
 	writeChunk := func(chunk *common.Message) (bool, error) {
+		if chunk != nil && chunk.Error != "" {
+			// Mid-stream failure (e.g. queue overflow, agent-side error).
+			// Surface it so the caller aborts the response instead of
+			// ending the truncated body cleanly.
+			return false, fmt.Errorf("stream aborted after %d bytes: %s", transferred, chunk.Error)
+		}
 		if chunk == nil || chunk.HTTP == nil {
 			return true, nil
 		}

--- a/modules/ztrouter/download_test.go
+++ b/modules/ztrouter/download_test.go
@@ -3,9 +3,11 @@ package ztrouter
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"sync"
 	"testing"
 	"time"
 
@@ -89,6 +91,228 @@ func TestHandler_DownloadStreaming(t *testing.T) {
 	}
 	if !bytes.Equal(rr.Body.Bytes(), payload) {
 		t.Fatalf("body len=%d want %d", rr.Body.Len(), len(payload))
+	}
+}
+
+// slowFlushRW is a ResponseWriter+Flusher whose Write is slow (and optionally
+// gated on a channel), simulating a client that reads slower than the agent
+// sends — the condition that made the old buffered-channel dispatch drop
+// streaming chunks.
+type slowFlushRW struct {
+	mu     sync.Mutex
+	buf    bytes.Buffer
+	code   int
+	header http.Header
+	delay  time.Duration
+	gate   chan struct{} // if non-nil, the first Write blocks until closed
+	gated  bool
+}
+
+func newSlowFlushRW(delay time.Duration, gate chan struct{}) *slowFlushRW {
+	return &slowFlushRW{header: make(http.Header), delay: delay, gate: gate}
+}
+
+func (s *slowFlushRW) Header() http.Header { return s.header }
+func (s *slowFlushRW) WriteHeader(c int)   { s.code = c }
+func (s *slowFlushRW) Flush()              {}
+func (s *slowFlushRW) Write(b []byte) (int, error) {
+	if s.gate != nil && !s.gated {
+		<-s.gate
+		s.gated = true
+	}
+	if s.delay > 0 {
+		time.Sleep(s.delay)
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.buf.Write(b)
+}
+
+func (s *slowFlushRW) bodyLen() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.buf.Len()
+}
+
+// runServeHTTPCatch runs ServeHTTP on a goroutine and reports the recovered
+// panic value (nil if it returned normally).
+func runServeHTTPCatch(handler *Handler, w http.ResponseWriter, r *http.Request) <-chan any {
+	out := make(chan any, 1)
+	go func() {
+		defer func() { out <- recover() }()
+		handler.ServeHTTP(w, r)
+	}()
+	return out
+}
+
+// startDownloadStream drives the harness up to the point where the agent
+// starts a streaming response: it issues the request, captures the response
+// callback, and dispatches the initial IsStream header message.
+func startDownloadStream(t *testing.T, h *testHarness, w http.ResponseWriter, total int64) (func(*common.Message), <-chan any) {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodGet, "http://"+h.agentHost()+"/big.js", nil)
+	done := runServeHTTPCatch(h.handler, w, req)
+
+	fwd := h.readForwardedRequest()
+	cb, ok := h.agent.TakeResponseHandler(fwd.ID)
+	if !ok {
+		t.Fatalf("no response handler registered")
+	}
+	h.agent.SetResponseHandler(fwd.ID, cb)
+
+	cb(&common.Message{
+		Type: "http_response",
+		ID:   fwd.ID,
+		HTTP: &common.HTTPData{
+			StatusCode: http.StatusOK,
+			Headers:    map[string][]string{"Content-Type": {"application/javascript"}},
+			IsStream:   true,
+			TotalSize:  total,
+		},
+	})
+	return cb, done
+}
+
+// TestHandler_DownloadStreaming_BurstNoDrop is the regression test for the
+// silent chunk-drop bug: an agent bursts far more chunks than the old
+// 16-message channel buffer while the client writes slowly. Every chunk must
+// still reach the client, in order, ending with IsLastChunk. With the old
+// select/default dispatch this test fails with a truncated body (and, when
+// the IsLastChunk message was dropped, a hang until timeout). Observed in the
+// wild as Synology DSM's UIString i18n script arriving truncated, which broke
+// the login page.
+func TestHandler_DownloadStreaming_BurstNoDrop(t *testing.T) {
+	const (
+		numChunks = 200
+		chunkSize = 4096
+	)
+	h := newHarness(t, "dl.example.com")
+
+	var expected bytes.Buffer
+	chunks := make([][]byte, numChunks)
+	for i := range chunks {
+		c := bytes.Repeat([]byte{0}, chunkSize)
+		copy(c, fmt.Sprintf("%06d|", i)) // ordering marker
+		chunks[i] = c
+		expected.Write(c)
+	}
+
+	w := newSlowFlushRW(200*time.Microsecond, nil)
+	cb, done := startDownloadStream(t, h, w, int64(expected.Len()))
+
+	// Burst all chunks synchronously, like the agent read loop does.
+	for i, c := range chunks {
+		cb(&common.Message{
+			Type: "http_response",
+			HTTP: &common.HTTPData{
+				Body:        c,
+				IsStream:    true,
+				ChunkIndex:  i + 1,
+				IsLastChunk: i == len(chunks)-1,
+			},
+		})
+	}
+
+	select {
+	case p := <-done:
+		if p != nil {
+			t.Fatalf("ServeHTTP panicked: %v", p)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatalf("stream did not complete: IsLastChunk was likely dropped (received %d of %d bytes)",
+			w.bodyLen(), expected.Len())
+	}
+
+	if w.code != http.StatusOK {
+		t.Fatalf("status=%d, want 200", w.code)
+	}
+	if !bytes.Equal(w.buf.Bytes(), expected.Bytes()) {
+		t.Fatalf("body truncated or reordered: got %d bytes, want %d", w.buf.Len(), expected.Len())
+	}
+}
+
+// TestHandler_DownloadStreaming_OverflowAborts verifies that when the byte
+// cap is genuinely exceeded the response is aborted (http.ErrAbortHandler)
+// rather than ended cleanly — a clean end would let clients cache the
+// truncated body as complete.
+func TestHandler_DownloadStreaming_OverflowAborts(t *testing.T) {
+	h := newHarness(t, "dl.example.com")
+	h.handler.maxStreamBuffer = 16 * 1024 // tiny cap to force overflow
+
+	gate := make(chan struct{})
+	w := newSlowFlushRW(0, gate)
+	cb, done := startDownloadStream(t, h, w, 1<<20)
+
+	// Flood while the writer is gated shut: respCh (16) fills, then the
+	// queue exceeds its 16 KiB cap.
+	chunk := bytes.Repeat([]byte("x"), 4096)
+	for i := 0; i < 60; i++ {
+		cb(&common.Message{
+			Type: "http_response",
+			HTTP: &common.HTTPData{Body: chunk, IsStream: true, ChunkIndex: i + 1},
+		})
+	}
+	close(gate) // let queued writes drain so the overflow sentinel is reached
+
+	select {
+	case p := <-done:
+		if p != http.ErrAbortHandler {
+			t.Fatalf("recovered %v, want http.ErrAbortHandler", p)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("ServeHTTP did not return after overflow")
+	}
+	if w.bodyLen() >= 60*len(chunk) {
+		t.Fatal("full body written despite overflow — abort came too late")
+	}
+}
+
+// TestHandler_DownloadStreaming_TimeoutAborts verifies that an inter-chunk
+// timeout aborts the response instead of ending the truncated body cleanly.
+func TestHandler_DownloadStreaming_TimeoutAborts(t *testing.T) {
+	h := newHarness(t, "dl.example.com")
+	h.handler.timeoutCfg = &common.TimeoutConfig{
+		StreamingTimeout: 50 * time.Millisecond,
+		LargeFileTimeout: 50 * time.Millisecond,
+	}
+
+	w := newSlowFlushRW(0, nil)
+	cb, done := startDownloadStream(t, h, w, 1)
+
+	// One data chunk, never the last one — the agent side went silent.
+	cb(&common.Message{
+		Type: "http_response",
+		HTTP: &common.HTTPData{Body: []byte("partial"), IsStream: true, ChunkIndex: 1},
+	})
+
+	select {
+	case p := <-done:
+		if p != http.ErrAbortHandler {
+			t.Fatalf("recovered %v, want http.ErrAbortHandler", p)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("ServeHTTP did not return after inter-chunk timeout")
+	}
+}
+
+// TestStreamDownloadFlush_ErrorChunkAborts verifies that an Error-carrying
+// message mid-stream surfaces as an error from the flush loop.
+func TestStreamDownloadFlush_ErrorChunkAborts(t *testing.T) {
+	h := &Handler{}
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/data", nil)
+	agent := newTestAgent(t, "a-errchunk")
+
+	respCh := make(chan *common.Message, 2)
+	respCh <- &common.Message{HTTP: &common.HTTPData{Body: []byte("data"), IsStream: true}}
+	respCh <- &common.Message{Error: "boom"}
+
+	initial := &common.Message{
+		HTTP: &common.HTTPData{StatusCode: http.StatusOK, Headers: map[string][]string{}},
+	}
+	err := h.streamDownloadFlush(rr, req, rr, agent, "msg-err", initial, respCh)
+	if err == nil {
+		t.Fatal("expected error from Error-carrying chunk, got nil")
 	}
 }
 

--- a/modules/ztrouter/handler.go
+++ b/modules/ztrouter/handler.go
@@ -6,7 +6,6 @@ import (
 	"net"
 	"net/http"
 	"strings"
-	"sync/atomic"
 	"time"
 
 	"github.com/google/uuid"
@@ -22,8 +21,9 @@ var log = logger.WithComponent("ztrouter")
 type Handler struct {
 	RequestTimeout time.Duration `json:"request_timeout,omitempty"`
 
-	app        *ztagents.App
-	timeoutCfg *common.TimeoutConfig // nil → common.DefaultTimeouts(); set in tests
+	app             *ztagents.App
+	timeoutCfg      *common.TimeoutConfig // nil → common.DefaultTimeouts(); set in tests
+	maxStreamBuffer int64                 // 0 → defaultMaxStreamBuffer; set in tests
 }
 
 // SetApp injects the ztagents App directly. Intended for tests; production code
@@ -79,20 +79,20 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	headers["Host"] = []string{host}
 	setForwardedHeaders(headers, r)
 
+	// Response messages flow: agent read loop → queue.push (never blocks) →
+	// pump goroutine → respCh (blocks; backpressure lands on the pump, not
+	// the shared read loop). The queue never drops chunks — the previous
+	// buffered-channel-with-default-drop here silently lost streaming chunks
+	// under bursts, truncating download bodies (and hanging the stream when
+	// the IsLastChunk message was the one dropped).
 	respCh := make(chan *common.Message, 16)
-	var closed int32
-	agent.SetResponseHandler(msgID, func(m *common.Message) {
-		if atomic.LoadInt32(&closed) == 1 {
-			return
-		}
-		select {
-		case respCh <- m:
-		default:
-		}
-	})
+	queue := newMsgQueue(h.maxStreamBuffer)
+	stop := make(chan struct{})
+	go queue.pump(r.Context(), stop, respCh)
+	agent.SetResponseHandler(msgID, queue.push)
 	defer func() {
-		atomic.StoreInt32(&closed, 1)
 		agent.TakeResponseHandler(msgID)
+		close(stop)
 	}()
 
 	if streamUpload {
@@ -159,9 +159,15 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			if err := h.handleDownloadStream(w, r, agent, msgID, resp, respCh); err != nil {
 				if isClientGone(err) {
 					log.Debug("ztrouter: download stream: client gone id=%s: %v", msgID, err)
-				} else {
-					log.Error("ztrouter: download stream: %v", err)
+					return
 				}
+				log.Error("ztrouter: download stream: id=%s: %v", msgID, err)
+				// Abort the response (HTTP/2 RST_STREAM, HTTP/1.1 connection
+				// close mid-body) so the client sees a failed transfer. A
+				// plain return would end the stream cleanly and clients —
+				// browsers especially — would treat the truncated body as
+				// complete and may cache it.
+				panic(http.ErrAbortHandler)
 			}
 			return
 		}

--- a/modules/ztrouter/handler_test.go
+++ b/modules/ztrouter/handler_test.go
@@ -23,7 +23,10 @@ type testHarness struct {
 	agent   *ztagents.Agent
 	client  net.Conn // reads what handler sends
 	handler *Handler
+	host    string
 }
+
+func (h *testHarness) agentHost() string { return h.host }
 
 func newHarness(t *testing.T, host string) *testHarness {
 	t.Helper()
@@ -44,7 +47,7 @@ func newHarness(t *testing.T, host string) *testHarness {
 	h := &Handler{RequestTimeout: 2 * time.Second}
 	h.SetApp(app)
 
-	return &testHarness{t: t, app: app, agent: agent, client: client, handler: h}
+	return &testHarness{t: t, app: app, agent: agent, client: client, handler: h, host: host}
 }
 
 // readForwardedRequest drains the pipe to capture the agent-bound message.

--- a/modules/ztrouter/queue.go
+++ b/modules/ztrouter/queue.go
@@ -15,6 +15,12 @@ import (
 // while still bounding per-request memory.
 const defaultMaxStreamBuffer = 32 << 20
 
+// msgOverheadBytes is charged against the byte cap per queued message in
+// addition to its body length. Without it, a flood of tiny chunks (say,
+// 1-byte bodies) would pass the cap while accumulating millions of Message
+// structs — far more real memory than the cap suggests.
+const msgOverheadBytes = 256
+
 // msgQueue is an unbounded-order, byte-capped FIFO between the agent
 // dispatch callback (producer, runs on the agent connection's read loop and
 // must never block) and the per-request pump goroutine (consumer).
@@ -28,6 +34,7 @@ const defaultMaxStreamBuffer = 32 << 20
 type msgQueue struct {
 	mu       sync.Mutex
 	items    []*common.Message
+	head     int // index of the next item to pop; see pop() for compaction
 	bytes    int64
 	maxBytes int64
 	overflow bool
@@ -47,9 +54,9 @@ func newMsgQueue(maxBytes int64) *msgQueue {
 // and all subsequent messages are discarded — the consumer aborts the stream,
 // so continuity is already lost.
 func (q *msgQueue) push(m *common.Message) {
-	var size int64
+	size := int64(msgOverheadBytes)
 	if m != nil && m.HTTP != nil {
-		size = int64(len(m.HTTP.Body))
+		size += int64(len(m.HTTP.Body))
 	}
 
 	q.mu.Lock()
@@ -70,17 +77,35 @@ func (q *msgQueue) push(m *common.Message) {
 }
 
 // pop removes and returns the head of the queue. ok is false when empty.
+//
+// A head index is used instead of re-slicing (items = items[1:]) so the
+// backing array can be compacted: re-slicing permanently retains every
+// pointer slot ever pushed, growing memory with total throughput rather
+// than queue depth.
 func (q *msgQueue) pop() (m *common.Message, ok bool) {
 	q.mu.Lock()
 	defer q.mu.Unlock()
-	if len(q.items) == 0 {
+	if q.head == len(q.items) {
 		return nil, false
 	}
-	m = q.items[0]
-	q.items[0] = nil // let the chunk body be collected promptly
-	q.items = q.items[1:]
+	m = q.items[q.head]
+	q.items[q.head] = nil // let the chunk body be collected promptly
+	q.head++
 	if m != nil && m.HTTP != nil {
 		q.bytes -= int64(len(m.HTTP.Body))
+	}
+	q.bytes -= msgOverheadBytes
+
+	switch {
+	case q.head == len(q.items):
+		// Drained — release the backing array entirely.
+		q.items = nil
+		q.head = 0
+	case q.head >= 256 && q.head*2 >= len(q.items):
+		// Mostly-consumed — shift the live window to the front so the
+		// backing array size tracks queue depth, not total throughput.
+		q.items = append(q.items[:0], q.items[q.head:]...)
+		q.head = 0
 	}
 	return m, true
 }
@@ -103,6 +128,16 @@ func (q *msgQueue) wake() {
 // not on the shared agent read loop). On overflow it delivers a final
 // Error-carrying message so the download loop aborts the response, then
 // exits. It returns when ctx is cancelled or stop is closed.
+//
+// Wake-up correctness: the coalesced capacity-1 signal cannot be "lost".
+// push makes the item visible (under q.mu) *before* wake(), and pump
+// re-checks the queue via pop() after *every* signal receipt. So whenever
+// pump blocks on q.signal, any item pushed after its last pop() has either
+// left a token in the channel (wake found it empty → pump unblocks) or
+// wake found the channel full — in which case that token is still there
+// and unblocks pump anyway; the follow-up pop() then observes the item.
+// A drained "stale" token merely causes one extra empty pop(), never a
+// missed item. Exercised by TestMsgQueue_PumpStress_NoLostWakeup.
 func (q *msgQueue) pump(ctx context.Context, stop <-chan struct{}, out chan<- *common.Message) {
 	for {
 		if m, ok := q.pop(); ok {

--- a/modules/ztrouter/queue.go
+++ b/modules/ztrouter/queue.go
@@ -1,0 +1,135 @@
+package ztrouter
+
+import (
+	"context"
+	"sync"
+
+	"github.com/devhatro/zero-trust-proxy/internal/common"
+)
+
+// defaultMaxStreamBuffer bounds how many response-body bytes may sit queued
+// between the agent mTLS read loop and a slow client writer before the
+// stream is aborted. Streaming responses have no flow control on the agent
+// leg — the agent sends chunks as fast as it reads them from the upstream —
+// so the router must buffer the burst. 32 MiB absorbs any realistic burst
+// while still bounding per-request memory.
+const defaultMaxStreamBuffer = 32 << 20
+
+// msgQueue is an unbounded-order, byte-capped FIFO between the agent
+// dispatch callback (producer, runs on the agent connection's read loop and
+// must never block) and the per-request pump goroutine (consumer).
+//
+// It replaces the previous buffered-channel-with-default-drop pattern, which
+// silently discarded streaming chunks whenever more than the channel
+// capacity were in flight — truncating download bodies mid-stream and, when
+// the IsLastChunk message was dropped, hanging the response until timeout.
+// Chunks are never dropped: if the byte cap is exceeded the queue flips to
+// overflow and the stream is aborted loudly instead.
+type msgQueue struct {
+	mu       sync.Mutex
+	items    []*common.Message
+	bytes    int64
+	maxBytes int64
+	overflow bool
+	signal   chan struct{} // capacity 1; coalesced wake-up for the consumer
+}
+
+func newMsgQueue(maxBytes int64) *msgQueue {
+	if maxBytes <= 0 {
+		maxBytes = defaultMaxStreamBuffer
+	}
+	return &msgQueue{maxBytes: maxBytes, signal: make(chan struct{}, 1)}
+}
+
+// push appends m. It never blocks: this is called from the agent read loop,
+// and blocking there would stall every multiplexed request on the agent
+// connection. Once the byte cap is exceeded the queue is marked overflowed
+// and all subsequent messages are discarded — the consumer aborts the stream,
+// so continuity is already lost.
+func (q *msgQueue) push(m *common.Message) {
+	var size int64
+	if m != nil && m.HTTP != nil {
+		size = int64(len(m.HTTP.Body))
+	}
+
+	q.mu.Lock()
+	if q.overflow {
+		q.mu.Unlock()
+		return
+	}
+	if q.bytes+size > q.maxBytes {
+		q.overflow = true
+		q.mu.Unlock()
+		q.wake()
+		return
+	}
+	q.items = append(q.items, m)
+	q.bytes += size
+	q.mu.Unlock()
+	q.wake()
+}
+
+// pop removes and returns the head of the queue. ok is false when empty.
+func (q *msgQueue) pop() (m *common.Message, ok bool) {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	if len(q.items) == 0 {
+		return nil, false
+	}
+	m = q.items[0]
+	q.items[0] = nil // let the chunk body be collected promptly
+	q.items = q.items[1:]
+	if m != nil && m.HTTP != nil {
+		q.bytes -= int64(len(m.HTTP.Body))
+	}
+	return m, true
+}
+
+func (q *msgQueue) overflowed() bool {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	return q.overflow
+}
+
+func (q *msgQueue) wake() {
+	select {
+	case q.signal <- struct{}{}:
+	default:
+	}
+}
+
+// pump forwards queued messages to out in order, blocking on the consumer
+// (that's the point: backpressure lands here, in a per-request goroutine,
+// not on the shared agent read loop). On overflow it delivers a final
+// Error-carrying message so the download loop aborts the response, then
+// exits. It returns when ctx is cancelled or stop is closed.
+func (q *msgQueue) pump(ctx context.Context, stop <-chan struct{}, out chan<- *common.Message) {
+	for {
+		if m, ok := q.pop(); ok {
+			select {
+			case out <- m:
+				continue
+			case <-ctx.Done():
+				return
+			case <-stop:
+				return
+			}
+		}
+		if q.overflowed() {
+			m := &common.Message{Error: "response stream buffer overflow: client reads slower than the agent sends and the buffer cap was reached"}
+			select {
+			case out <- m:
+			case <-ctx.Done():
+			case <-stop:
+			}
+			return
+		}
+		select {
+		case <-q.signal:
+		case <-ctx.Done():
+			return
+		case <-stop:
+			return
+		}
+	}
+}

--- a/modules/ztrouter/queue_test.go
+++ b/modules/ztrouter/queue_test.go
@@ -1,0 +1,138 @@
+package ztrouter
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/devhatro/zero-trust-proxy/internal/common"
+)
+
+func chunkMsg(body []byte) *common.Message {
+	return &common.Message{HTTP: &common.HTTPData{Body: body, IsStream: true}}
+}
+
+func TestMsgQueue_FIFOAndByteAccounting(t *testing.T) {
+	q := newMsgQueue(1 << 20)
+
+	for i := 0; i < 50; i++ {
+		q.push(chunkMsg([]byte{byte(i)}))
+	}
+	for i := 0; i < 50; i++ {
+		m, ok := q.pop()
+		if !ok {
+			t.Fatalf("pop %d: queue empty", i)
+		}
+		if m.HTTP.Body[0] != byte(i) {
+			t.Fatalf("pop %d: got %d, want %d — order not preserved", i, m.HTTP.Body[0], i)
+		}
+	}
+	if _, ok := q.pop(); ok {
+		t.Fatal("queue should be empty")
+	}
+	if q.bytes != 0 {
+		t.Fatalf("bytes=%d after draining, want 0", q.bytes)
+	}
+	if q.overflowed() {
+		t.Fatal("queue should not have overflowed")
+	}
+}
+
+func TestMsgQueue_NeverDropsWithinCap(t *testing.T) {
+	// 1000 messages of 1 KiB — far beyond the old 16-message channel buffer.
+	q := newMsgQueue(2 << 20)
+	body := make([]byte, 1024)
+	for i := 0; i < 1000; i++ {
+		q.push(chunkMsg(body))
+	}
+	n := 0
+	for {
+		if _, ok := q.pop(); !ok {
+			break
+		}
+		n++
+	}
+	if n != 1000 {
+		t.Fatalf("popped %d messages, want 1000 — chunks were dropped", n)
+	}
+}
+
+func TestMsgQueue_OverflowFlipsAndDiscards(t *testing.T) {
+	q := newMsgQueue(10) // 10-byte cap
+
+	q.push(chunkMsg([]byte("12345")))  // 5 bytes — fits
+	q.push(chunkMsg([]byte("678901"))) // 11 total — overflow
+	if !q.overflowed() {
+		t.Fatal("queue should have overflowed")
+	}
+	// Post-overflow pushes are discarded.
+	q.push(chunkMsg([]byte("x")))
+
+	m, ok := q.pop()
+	if !ok || string(m.HTTP.Body) != "12345" {
+		t.Fatalf("pre-overflow item should still pop; got ok=%v", ok)
+	}
+	if _, ok := q.pop(); ok {
+		t.Fatal("overflowing and post-overflow items must not be queued")
+	}
+}
+
+func TestMsgQueue_PumpDeliversInOrderThenStops(t *testing.T) {
+	q := newMsgQueue(1 << 20)
+	out := make(chan *common.Message, 4)
+	stop := make(chan struct{})
+	pumpDone := make(chan struct{})
+	go func() {
+		defer close(pumpDone)
+		q.pump(context.Background(), stop, out)
+	}()
+
+	for i := 0; i < 100; i++ {
+		q.push(chunkMsg([]byte{byte(i)}))
+	}
+	for i := 0; i < 100; i++ {
+		select {
+		case m := <-out:
+			if m.HTTP.Body[0] != byte(i) {
+				t.Fatalf("chunk %d: got %d — out of order", i, m.HTTP.Body[0])
+			}
+		case <-time.After(2 * time.Second):
+			t.Fatalf("pump stalled at chunk %d", i)
+		}
+	}
+
+	close(stop)
+	select {
+	case <-pumpDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("pump did not exit after stop")
+	}
+}
+
+func TestMsgQueue_PumpEmitsOverflowSentinel(t *testing.T) {
+	q := newMsgQueue(4)
+	out := make(chan *common.Message, 8)
+	stop := make(chan struct{})
+	defer close(stop)
+	go q.pump(context.Background(), stop, out)
+
+	q.push(chunkMsg([]byte("abcd"))) // fills the cap exactly
+	q.push(chunkMsg([]byte("e")))    // overflow
+
+	var got []*common.Message
+	deadline := time.After(2 * time.Second)
+	for len(got) < 2 {
+		select {
+		case m := <-out:
+			got = append(got, m)
+		case <-deadline:
+			t.Fatalf("received %d messages, want data + overflow sentinel", len(got))
+		}
+	}
+	if string(got[0].HTTP.Body) != "abcd" {
+		t.Fatalf("first message body=%q, want pre-overflow data", got[0].HTTP.Body)
+	}
+	if got[1].Error == "" {
+		t.Fatal("second message should be the overflow sentinel carrying Error")
+	}
+}

--- a/modules/ztrouter/queue_test.go
+++ b/modules/ztrouter/queue_test.go
@@ -58,10 +58,11 @@ func TestMsgQueue_NeverDropsWithinCap(t *testing.T) {
 }
 
 func TestMsgQueue_OverflowFlipsAndDiscards(t *testing.T) {
-	q := newMsgQueue(10) // 10-byte cap
+	// Cap fits one message (body + msgOverheadBytes) but not two.
+	q := newMsgQueue(msgOverheadBytes + 50)
 
-	q.push(chunkMsg([]byte("12345")))  // 5 bytes — fits
-	q.push(chunkMsg([]byte("678901"))) // 11 total — overflow
+	q.push(chunkMsg([]byte("12345")))  // fits
+	q.push(chunkMsg([]byte("678901"))) // second message overflows
 	if !q.overflowed() {
 		t.Fatal("queue should have overflowed")
 	}
@@ -110,7 +111,7 @@ func TestMsgQueue_PumpDeliversInOrderThenStops(t *testing.T) {
 }
 
 func TestMsgQueue_PumpEmitsOverflowSentinel(t *testing.T) {
-	q := newMsgQueue(4)
+	q := newMsgQueue(msgOverheadBytes + 4) // exactly one 4-byte message
 	out := make(chan *common.Message, 8)
 	stop := make(chan struct{})
 	defer close(stop)
@@ -134,5 +135,82 @@ func TestMsgQueue_PumpEmitsOverflowSentinel(t *testing.T) {
 	}
 	if got[1].Error == "" {
 		t.Fatal("second message should be the overflow sentinel carrying Error")
+	}
+}
+
+// TestMsgQueue_CompactsBackingArray verifies that sustained push/pop traffic
+// does not grow the backing array with total throughput (the items=items[1:]
+// re-slice pattern would retain a slot for every message ever pushed), and
+// that draining releases the array entirely.
+func TestMsgQueue_CompactsBackingArray(t *testing.T) {
+	q := newMsgQueue(1 << 20)
+	body := []byte("x")
+
+	for i := 0; i < 10_000; i++ {
+		q.push(chunkMsg(body))
+		q.push(chunkMsg(body))
+		if _, ok := q.pop(); !ok {
+			t.Fatalf("iteration %d: pop failed", i)
+		}
+		if _, ok := q.pop(); !ok {
+			t.Fatalf("iteration %d: second pop failed", i)
+		}
+	}
+
+	q.mu.Lock()
+	itemsNil, head, capacity := q.items == nil, q.head, cap(q.items)
+	q.mu.Unlock()
+	if !itemsNil {
+		t.Fatalf("drained queue retains backing array: head=%d cap=%d", head, capacity)
+	}
+
+	// Steady-state with a shallow queue must keep the array shallow too.
+	for i := 0; i < 10_000; i++ {
+		q.push(chunkMsg(body))
+		if i >= 2 {
+			if _, ok := q.pop(); !ok {
+				t.Fatalf("iteration %d: pop failed", i)
+			}
+		}
+	}
+	q.mu.Lock()
+	capacity = cap(q.items)
+	q.mu.Unlock()
+	if capacity > 4096 {
+		t.Fatalf("backing array grew with throughput: cap=%d for a depth-3 queue", capacity)
+	}
+}
+
+// TestMsgQueue_PumpStress_NoLostWakeup hammers the producer/consumer pair to
+// exercise the coalesced-signal wake-up path: every pushed item must reach
+// the consumer even when pushes race with the pump draining stale tokens.
+// Run with -race.
+func TestMsgQueue_PumpStress_NoLostWakeup(t *testing.T) {
+	const n = 5000
+	q := newMsgQueue(64 << 20)
+	out := make(chan *common.Message) // unbuffered: maximise interleavings
+	stop := make(chan struct{})
+	defer close(stop)
+	go q.pump(context.Background(), stop, out)
+
+	go func() {
+		for i := 0; i < n; i++ {
+			q.push(chunkMsg([]byte{byte(i), byte(i >> 8)}))
+			if i%97 == 0 {
+				time.Sleep(time.Microsecond) // let the queue drain to empty
+			}
+		}
+	}()
+
+	for i := 0; i < n; i++ {
+		select {
+		case m := <-out:
+			got := int(m.HTTP.Body[0]) | int(m.HTTP.Body[1])<<8
+			if got != i&0xffff {
+				t.Fatalf("item %d: got marker %d — out of order or dropped", i, got)
+			}
+		case <-time.After(5 * time.Second):
+			t.Fatalf("stalled at item %d/%d — lost wake-up", i, n)
+		}
 	}
 }


### PR DESCRIPTION
## Summary

- Replace silent-discard buffered-channel dispatch with a never-dropping byte-capped FIFO queue applied at the per-request level
- Backpressure lands on a pump goroutine, not the shared agent mTLS read loop (no head-of-line blocking)
- On byte-cap overflow the stream is aborted via `http.ErrAbortHandler` → h2 RST_STREAM / h1 mid-body close, preventing cache poisoning
- Fixes DSM login page blank issue: previously the Synology UIString API response was truncated mid-stream (dropped `IsLastChunk`), hung, ended cleanly, and was cached for a year

## Test plan

- [x] `go test ./... -count=1` — 527 tests pass
- [x] `go test ./modules/ztrouter/ -count=1 -race` — race detector clean
- [x] `go vet ./modules/ztrouter/` — no issues
- [x] `make sec` — no HIGH findings (G402 already exempted)
- [x] Regression test `TestHandler_DownloadStreaming_BurstNoDrop` fails on old code (IsLastChunk dropped at ~65 KB), passes on new code
- [x] `TestMsgQueue_*` unit tests (5) verify FIFO order, byte accounting, overflow sentinel
- [x] `TestHandler_DownloadStreaming_OverflowAborts` confirms abort-not-close on cap exceeded
- [x] `TestStreamDownloadFlush_ErrorChunkAborts` confirms Error-carrying message causes stream abort
<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Replace lossy buffered-channel dispatch with a byte-capped queue to prevent silent streaming response chunk drops and enable proper error handling for buffer overflows.

Main changes:
- Implement msgQueue with byte-capped FIFO and overflow sentinel to guarantee chunk delivery and abort truncated streams
- Add error-carrying message detection in streamDownloadFlush to surface mid-stream failures instead of silently truncating responses
- Replace atomic flag + select/default pattern with dedicated pump goroutine providing backpressure isolation from agent read loop

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
