### PR TITLE
fix(agent,ztrouter): WebSocket upgrade reliability — dial backends by their scheme, preserve glued frames

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -96,6 +96,67 @@ func needsTLS(service *common.ServiceConfig, backendAddr string) bool {
 	return false
 }
 
+// wsDialPlan resolves the dial address and TLS mode for a WebSocket backend.
+// The backend's own scheme prefix is authoritative: service.Protocol describes
+// the client-facing leg, and a service exposed as https very commonly fronts a
+// plain-http backend (e.g. Home Assistant on http://host:8123). Overriding an
+// explicit http:// prefix with TLS — as needsTLS' service-protocol priority
+// would — makes the dial fail while regular HTTP requests to the same backend
+// succeed. This mirrors the precedence handleHTTPRequest uses ("backend
+// already has protocol, use as-is"); needsTLS is only consulted when the
+// backend address carries no scheme.
+func wsDialPlan(service *common.ServiceConfig, backend string) (addr string, useTLS bool) {
+	switch {
+	case strings.HasPrefix(backend, "https://"):
+		addr, useTLS = strings.TrimPrefix(backend, "https://"), true
+	case strings.HasPrefix(backend, "wss://"):
+		addr, useTLS = strings.TrimPrefix(backend, "wss://"), true
+	case strings.HasPrefix(backend, "http://"):
+		addr, useTLS = strings.TrimPrefix(backend, "http://"), false
+	case strings.HasPrefix(backend, "ws://"):
+		addr, useTLS = strings.TrimPrefix(backend, "ws://"), false
+	default:
+		addr, useTLS = backend, needsTLS(service, backend)
+	}
+	// net.Dial needs an explicit port; URLs get theirs from the scheme.
+	if !strings.Contains(addr, ":") {
+		if useTLS {
+			addr += ":443"
+		} else {
+			addr += ":80"
+		}
+	}
+	return addr, useTLS
+}
+
+// readUpgradeResponse reads from conn until the HTTP response header
+// terminator ("\r\n\r\n") has arrived, returning everything read so far —
+// headers plus any bytes glued after them. A single fixed-size read can
+// truncate the headers or silently swallow the backend's first WebSocket
+// frame: Home Assistant, for one, writes its auth_required frame immediately
+// after the 101, often in the same TCP segment. Those trailing bytes must be
+// preserved (they are forwarded as the response body) or the client hangs
+// waiting for a frame that never arrives.
+func readUpgradeResponse(conn net.Conn) ([]byte, error) {
+	var buf []byte
+	tmp := make([]byte, 4096)
+	for {
+		n, err := conn.Read(tmp)
+		if n > 0 {
+			buf = append(buf, tmp[:n]...)
+			if bytes.Contains(buf, []byte("\r\n\r\n")) {
+				return buf, nil
+			}
+			if len(buf) > 64*1024 {
+				return nil, fmt.Errorf("upgrade response headers exceed 64KiB")
+			}
+		}
+		if err != nil {
+			return nil, err
+		}
+	}
+}
+
 // getHealthCheckScheme determines the HTTP scheme for health checks
 func getHealthCheckScheme(service *ServiceConfig, upstreamAddr string) string {
 	// Priority 1: Service protocol setting
@@ -1011,25 +1072,12 @@ func (a *Agent) handleWebSocketConnection(msg *common.Message, service *common.S
 		log.Debug("📊 After cleanup delay: Active=%d connections", activeConnections)
 	}
 
-	// Extract backend address
-	backend := service.Backend
-	backendAddr := backend
+	// Resolve dial address and TLS mode. The backend's explicit scheme wins —
+	// service.Protocol is the client-facing protocol and must not force TLS
+	// onto a plain-http backend (see wsDialPlan).
+	backendAddr, shouldUseTLS := wsDialPlan(service, service.Backend)
 
-	// Remove protocol prefix if present and determine the actual address
-	if strings.HasPrefix(backend, "http://") {
-		backendAddr = strings.TrimPrefix(backend, "http://")
-	} else if strings.HasPrefix(backend, "https://") {
-		backendAddr = strings.TrimPrefix(backend, "https://")
-	} else if strings.HasPrefix(backend, "ws://") {
-		backendAddr = strings.TrimPrefix(backend, "ws://")
-	} else if strings.HasPrefix(backend, "wss://") {
-		backendAddr = strings.TrimPrefix(backend, "wss://")
-	}
-
-	log.Info("🔗 Connecting to WebSocket backend: %s", backendAddr)
-
-	// Determine if we need TLS based on the service protocol or backend address
-	shouldUseTLS := needsTLS(service, backendAddr)
+	log.Info("🔗 Connecting to WebSocket backend: %s (tls=%v)", backendAddr, shouldUseTLS)
 
 	var backendConn net.Conn
 	var err error
@@ -1089,15 +1137,15 @@ func (a *Agent) handleWebSocketConnection(msg *common.Message, service *common.S
 
 	log.Debug("📤 Sent WebSocket upgrade request to backend")
 
-	// Read the upgrade response from backend
-	buffer := make([]byte, 4096)
-	n, err := backendConn.Read(buffer)
+	// Read the upgrade response from backend — complete headers plus any
+	// glued first-frame bytes (forwarded to the client via the response body).
+	raw, err := readUpgradeResponse(backendConn)
 	if err != nil {
 		log.Error("❌ Failed to read upgrade response from backend: %v", err)
 		return
 	}
 
-	response := string(buffer[:n])
+	response := string(raw)
 	log.Info("📥 Backend WebSocket response: %s", strings.Split(response, "\r\n")[0])
 
 	// Debug: Log the complete response for troubleshooting

--- a/internal/agent/websocket_dial_test.go
+++ b/internal/agent/websocket_dial_test.go
@@ -1,0 +1,123 @@
+package agent
+
+import (
+	"bytes"
+	"net"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/devhatro/zero-trust-proxy/internal/common"
+	"github.com/devhatro/zero-trust-proxy/internal/types"
+)
+
+func svcWithProtocol(protocol string) *common.ServiceConfig {
+	return &common.ServiceConfig{
+		ServiceConfig: types.ServiceConfig{Hostname: "svc.example.com", Protocol: protocol},
+	}
+}
+
+// TestWSDialPlan verifies that the backend's explicit scheme wins over the
+// client-facing service protocol — the regression that made WebSocket dials
+// use TLS against plain-http backends (e.g. Home Assistant behind an https
+// service) while regular HTTP requests to the same backend worked.
+func TestWSDialPlan(t *testing.T) {
+	cases := []struct {
+		name     string
+		protocol string // service.Protocol (client-facing)
+		backend  string
+		wantAddr string
+		wantTLS  bool
+	}{
+		{"http backend under https service", "https", "http://10.0.0.5:8123", "10.0.0.5:8123", false},
+		{"ws backend under https service", "https", "ws://10.0.0.5:8123", "10.0.0.5:8123", false},
+		{"https backend under http service", "http", "https://10.0.0.5:8443", "10.0.0.5:8443", true},
+		{"wss backend", "http", "wss://10.0.0.5:8443", "10.0.0.5:8443", true},
+		{"no scheme falls back to service protocol https", "https", "10.0.0.5:8123", "10.0.0.5:8123", true},
+		{"no scheme falls back to service protocol http", "http", "10.0.0.5:8123", "10.0.0.5:8123", false},
+		{"https backend without port gets 443", "http", "https://backend.internal", "backend.internal:443", true},
+		{"http backend without port gets 80", "https", "http://backend.internal", "backend.internal:80", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			addr, useTLS := wsDialPlan(svcWithProtocol(tc.protocol), tc.backend)
+			if addr != tc.wantAddr || useTLS != tc.wantTLS {
+				t.Fatalf("wsDialPlan(%q, protocol=%q) = (%q, %v), want (%q, %v)",
+					tc.backend, tc.protocol, addr, useTLS, tc.wantAddr, tc.wantTLS)
+			}
+		})
+	}
+}
+
+// TestReadUpgradeResponse_GluedFrame verifies that bytes the backend sends in
+// the same segment as its 101 response (its first WebSocket frame) are
+// preserved rather than truncated away.
+func TestReadUpgradeResponse_GluedFrame(t *testing.T) {
+	client, server := net.Pipe()
+	defer client.Close()
+	defer server.Close()
+
+	headers := "HTTP/1.1 101 Switching Protocols\r\nUpgrade: websocket\r\nConnection: Upgrade\r\n\r\n"
+	frame := []byte{0x81, 0x05, 'h', 'e', 'l', 'l', 'o'} // tiny WS text frame
+	go func() {
+		_, _ = server.Write(append([]byte(headers), frame...))
+	}()
+
+	_ = client.SetReadDeadline(time.Now().Add(2 * time.Second))
+	raw, err := readUpgradeResponse(client)
+	if err != nil {
+		t.Fatalf("readUpgradeResponse: %v", err)
+	}
+	if !strings.HasPrefix(string(raw), "HTTP/1.1 101") {
+		t.Fatalf("raw does not start with the status line: %q", raw[:min(len(raw), 40)])
+	}
+	if !bytes.HasSuffix(raw, frame) {
+		t.Fatalf("glued frame bytes were lost: raw ends with %q", raw[max(0, len(raw)-10):])
+	}
+}
+
+// TestReadUpgradeResponse_SplitHeaders verifies that headers spanning
+// multiple reads are reassembled instead of being cut at the first read.
+func TestReadUpgradeResponse_SplitHeaders(t *testing.T) {
+	client, server := net.Pipe()
+	defer client.Close()
+	defer server.Close()
+
+	part1 := "HTTP/1.1 101 Switching Protocols\r\nUpgrade: web"
+	part2 := "socket\r\n\r\n"
+	go func() {
+		_, _ = server.Write([]byte(part1))
+		time.Sleep(20 * time.Millisecond)
+		_, _ = server.Write([]byte(part2))
+	}()
+
+	_ = client.SetReadDeadline(time.Now().Add(2 * time.Second))
+	raw, err := readUpgradeResponse(client)
+	if err != nil {
+		t.Fatalf("readUpgradeResponse: %v", err)
+	}
+	if string(raw) != part1+part2 {
+		t.Fatalf("raw = %q, want reassembled headers", raw)
+	}
+}
+
+// TestReadUpgradeResponse_OversizedHeaders verifies the 64KiB guard.
+func TestReadUpgradeResponse_OversizedHeaders(t *testing.T) {
+	client, server := net.Pipe()
+	defer client.Close()
+	defer server.Close()
+
+	go func() {
+		junk := bytes.Repeat([]byte("X"), 4096)
+		for i := 0; i < 20; i++ { // 80KiB, no terminator
+			if _, err := server.Write(junk); err != nil {
+				return
+			}
+		}
+	}()
+
+	_ = client.SetReadDeadline(time.Now().Add(2 * time.Second))
+	if _, err := readUpgradeResponse(client); err == nil {
+		t.Fatal("expected error for oversized headers, got nil")
+	}
+}

--- a/modules/ztrouter/websocket.go
+++ b/modules/ztrouter/websocket.go
@@ -69,6 +69,18 @@ func (h *Handler) handleWebSocketUpgrade(
 	if bufrw != nil {
 		_ = bufrw.Writer.Flush()
 	}
+	// Bytes the backend sent glued to its 101 — typically its first WebSocket
+	// frame (e.g. Home Assistant's auth_required) — arrive in the response
+	// body. Forward them here, on the same writer as the 101, so they reach
+	// the client in order instead of being silently dropped.
+	if len(resp.HTTP.Body) > 0 {
+		if _, err := clientConn.Write(resp.HTTP.Body); err != nil {
+			h.app.UnregisterWebSocket(msgID)
+			_ = clientConn.Close()
+			return fmt.Errorf("write initial ws frame (%d bytes): %w", len(resp.HTTP.Body), err)
+		}
+		log.Debug("ztrouter: ws forwarded %d glued handshake bytes id=%s", len(resp.HTTP.Body), msgID)
+	}
 	log.Info("ztrouter: ws upgraded id=%s agent=%s", msgID, agent.ID)
 
 	h.relayClientFrames(clientConn, bufrw, agent, msgID)

--- a/modules/ztrouter/websocket_test.go
+++ b/modules/ztrouter/websocket_test.go
@@ -225,6 +225,79 @@ func drainForMessageType(t *testing.T, c net.Conn, msgType string) *common.Messa
 	}
 }
 
+// TestHandleWebSocketUpgrade_ForwardsGluedBody verifies that bytes the agent
+// captured after the backend's 101 headers (the backend's first WebSocket
+// frame, e.g. Home Assistant's auth_required) are written to the client right
+// after the upgrade response instead of being dropped.
+func TestHandleWebSocketUpgrade_ForwardsGluedBody(t *testing.T) {
+	h := &Handler{}
+	app := ztagents.NewTestApp()
+	h.SetApp(app)
+
+	agentClient, agentServer := net.Pipe()
+	defer agentClient.Close()
+	defer agentServer.Close()
+	agent := ztagents.NewAgent("a-glued", agentServer)
+	// Drain agent-bound messages (websocket_disconnect on relay teardown).
+	go func() { _, _ = io.Copy(io.Discard, agentClient) }()
+
+	serverSide, clientSide := net.Pipe()
+	defer serverSide.Close()
+	defer clientSide.Close()
+	rec := &hijackRecorder{conn: serverSide}
+
+	frame := []byte{0x81, 0x0d, 'a', 'u', 't', 'h', '_', 'r', 'e', 'q', 'u', 'i', 'r', 'e', 'd'}
+	resp := &common.Message{
+		Type: "http_response",
+		ID:   "ws-glued-1",
+		HTTP: &common.HTTPData{
+			StatusCode:    http.StatusSwitchingProtocols,
+			StatusMessage: "101 Switching Protocols",
+			Headers:       map[string][]string{"Upgrade": {"websocket"}, "Connection": {"Upgrade"}},
+			Body:          frame, // glued first-frame bytes from the backend
+			IsWebSocket:   true,
+		},
+	}
+
+	done := make(chan error, 1)
+	go func() { done <- h.handleWebSocketUpgrade(rec, agent, "ws-glued-1", resp) }()
+
+	// Read the 101 + glued frame from the client side of the hijacked conn.
+	_ = clientSide.SetReadDeadline(time.Now().Add(2 * time.Second))
+	var got []byte
+	buf := make([]byte, 4096)
+	for !bytes.HasSuffix(got, frame) {
+		n, err := clientSide.Read(buf)
+		if n > 0 {
+			got = append(got, buf[:n]...)
+		}
+		if err != nil {
+			t.Fatalf("client read: %v (received %q)", err, got)
+		}
+	}
+	if !bytes.HasPrefix(got, []byte("HTTP/1.1 101")) {
+		t.Fatalf("client did not receive the 101 first: %q", got[:min(len(got), 40)])
+	}
+	if !bytes.Contains(got, frame) {
+		t.Fatalf("glued frame not forwarded: %q", got)
+	}
+	// The frame must come after the header terminator.
+	if idx := bytes.Index(got, []byte("\r\n\r\n")); !bytes.Equal(got[idx+4:], frame) {
+		t.Fatalf("bytes after headers = %q, want the glued frame", got[idx+4:])
+	}
+
+	// End the relay: closing the client conn makes relayClientFrames return.
+	_ = clientSide.Close()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("handleWebSocketUpgrade: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("handleWebSocketUpgrade did not return after client close")
+	}
+}
+
 // TestHandleWebSocketUpgrade_NoHijacker verifies the 500 path when the
 // ResponseWriter doesn't implement http.Hijacker.
 func TestHandleWebSocketUpgrade_NoHijacker(t *testing.T) {


### PR DESCRIPTION
## Summary

- **Bug 1 (agent WS dial):** needsTLS() forced TLS onto plain-HTTP backends exposed as https (e.g. Home Assistant on http://host:8123 behind an https service), causing 502. Regular HTTP requests to the same backend worked because handleHTTPRequest honors the backend's scheme. Fix: new wsDialPlan() gives explicit backend schemes priority; service.Protocol only applies when the backend has no scheme. Also adds default ports (:80/:443).

- **Bug 2 (glued frames dropped):** Agent read the 101 with one fixed 4096-byte read; if the backend's first frame (e.g. auth_required) arrived in the same segment it landed in the response Body — which the server discarded when writing only headers. Client hung forever. Fix: readUpgradeResponse() reassembles split headers and keeps glued bytes; the server writes resp.HTTP.Body right after the 101.

## Test plan

- [x] `go test ./... -count=1` — 542 tests pass
- [x] `go test ./internal/agent ./modules/ztrouter -count=1 -race` — race detector clean
- [x] `go vet ./internal/agent ./modules/ztrouter` — clean
- [x] `make sec` — no HIGH findings
- [x] TestWSDialPlan (8 cases) — backend scheme priority, port defaults
- [x] TestReadUpgradeResponse_GluedFrame, SplitHeaders, OversizedHeaders — glued-frame preservation, reassembly, 64 KiB guard
- [x] TestHandleWebSocketUpgrade_ForwardsGluedBody — server forwards 101 + glued body correctly
- [x] Live test against Home Assistant: WS upgrade now succeeds (was failing 100% before)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved WebSocket connections so the first message frame is no longer lost when it arrives immediately after the upgrade response.
  * Made backend connection handling more reliable by respecting the backend’s URL scheme and using the right port when one isn’t specified.
  * Added safer handling for upgrade responses, including support for split headers and protection against oversized responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Fix WebSocket upgrade reliability by respecting backend scheme prefixes and preserving glued frames after HTTP 101 responses.

Main changes:
- Added `wsDialPlan()` function that authorizes backend scheme over service protocol, preventing TLS mismatches on plain-http backends behind https services
- Implemented `readUpgradeResponse()` to accumulate complete headers and glued first-frame bytes instead of single fixed-size read truncation
- Forward accumulated glued frame bytes to client immediately after 101 response in ztrouter handler, preventing silent frame loss

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
