### PR TITLE
fix(agent): harden WebSocket dial address parsing and bound the upgrade read

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -106,27 +106,55 @@ func needsTLS(service *common.ServiceConfig, backendAddr string) bool {
 // already has protocol, use as-is"); needsTLS is only consulted when the
 // backend address carries no scheme.
 func wsDialPlan(service *common.ServiceConfig, backend string) (addr string, useTLS bool) {
-	switch {
-	case strings.HasPrefix(backend, "https://"):
-		addr, useTLS = strings.TrimPrefix(backend, "https://"), true
-	case strings.HasPrefix(backend, "wss://"):
-		addr, useTLS = strings.TrimPrefix(backend, "wss://"), true
-	case strings.HasPrefix(backend, "http://"):
-		addr, useTLS = strings.TrimPrefix(backend, "http://"), false
-	case strings.HasPrefix(backend, "ws://"):
-		addr, useTLS = strings.TrimPrefix(backend, "ws://"), false
-	default:
-		addr, useTLS = backend, needsTLS(service, backend)
-	}
-	// net.Dial needs an explicit port; URLs get theirs from the scheme.
-	if !strings.Contains(addr, ":") {
-		if useTLS {
-			addr += ":443"
-		} else {
-			addr += ":80"
+	scheme, rest := "", backend
+	for _, p := range []string{"https://", "wss://", "http://", "ws://"} {
+		if strings.HasPrefix(backend, p) {
+			scheme = strings.TrimSuffix(p, "://")
+			rest = strings.TrimPrefix(backend, p)
+			break
 		}
 	}
-	return addr, useTLS
+	// Drop any path component — net.Dial wants host:port only.
+	if i := strings.Index(rest, "/"); i >= 0 {
+		rest = rest[:i]
+	}
+	switch scheme {
+	case "https", "wss":
+		useTLS = true
+	case "http", "ws":
+		useTLS = false
+	default:
+		useTLS = needsTLS(service, rest)
+	}
+	return ensureDialPort(rest, useTLS), useTLS
+}
+
+// upgradeResponseTimeout bounds how long the agent waits for a backend's
+// WebSocket upgrade response headers.
+const upgradeResponseTimeout = 30 * time.Second
+
+// dialHostname extracts the host part of a host:port dial address for use as
+// a TLS ServerName. strings.Split(addr, ":")[0] breaks on bracketed IPv6
+// literals ("[::1]:443" would yield "[").
+func dialHostname(addr string) string {
+	if host, _, err := net.SplitHostPort(addr); err == nil {
+		return host
+	}
+	return addr
+}
+
+// ensureDialPort appends the scheme-implied default port when addr has none.
+// A plain strings.Contains(addr, ":") check misclassifies bracketed IPv6
+// literals ([::1] has colons but no port); net.SplitHostPort gets this right.
+func ensureDialPort(addr string, useTLS bool) string {
+	if _, _, err := net.SplitHostPort(addr); err == nil {
+		return addr
+	}
+	port := "80"
+	if useTLS {
+		port = "443"
+	}
+	return net.JoinHostPort(strings.Trim(addr, "[]"), port)
 }
 
 // readUpgradeResponse reads from conn until the HTTP response header
@@ -137,7 +165,15 @@ func wsDialPlan(service *common.ServiceConfig, backend string) (addr string, use
 // after the 101, often in the same TCP segment. Those trailing bytes must be
 // preserved (they are forwarded as the response body) or the client hangs
 // waiting for a frame that never arrives.
-func readUpgradeResponse(conn net.Conn) ([]byte, error) {
+//
+// The timeout bounds the whole read: a backend that sends partial headers and
+// stalls must not pin this goroutine (and its TCP connection) forever. The
+// deadline is cleared on return — the long-lived frame relay that follows
+// must not inherit it.
+func readUpgradeResponse(conn net.Conn, timeout time.Duration) ([]byte, error) {
+	_ = conn.SetReadDeadline(time.Now().Add(timeout))
+	defer func() { _ = conn.SetReadDeadline(time.Time{}) }()
+
 	var buf []byte
 	tmp := make([]byte, 4096)
 	for {
@@ -1087,7 +1123,7 @@ func (a *Agent) handleWebSocketConnection(msg *common.Message, service *common.S
 		log.Debug("🔒 Using TLS connection for HTTPS/WSS backend")
 		tlsConfig := &tls.Config{
 			InsecureSkipVerify: true,                               // Skip verification for backends (like curl -k)
-			ServerName:         strings.Split(backendAddr, ":")[0], // Extract hostname
+			ServerName:         dialHostname(backendAddr), // hostname without port (IPv6-safe)
 		}
 		backendConn, err = tls.DialWithDialer(&net.Dialer{Timeout: 10 * time.Second}, "tcp", backendAddr, tlsConfig)
 	} else {
@@ -1139,7 +1175,7 @@ func (a *Agent) handleWebSocketConnection(msg *common.Message, service *common.S
 
 	// Read the upgrade response from backend — complete headers plus any
 	// glued first-frame bytes (forwarded to the client via the response body).
-	raw, err := readUpgradeResponse(backendConn)
+	raw, err := readUpgradeResponse(backendConn, upgradeResponseTimeout)
 	if err != nil {
 		log.Error("❌ Failed to read upgrade response from backend: %v", err)
 		return

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -154,7 +154,13 @@ func ensureDialPort(addr string, useTLS bool) string {
 	if useTLS {
 		port = "443"
 	}
-	return net.JoinHostPort(strings.Trim(addr, "[]"), port)
+	// Unwrap only a matched bracket pair — strings.Trim("[]") would also eat
+	// stray brackets from malformed hostnames.
+	host := addr
+	if strings.HasPrefix(host, "[") && strings.HasSuffix(host, "]") {
+		host = host[1 : len(host)-1]
+	}
+	return net.JoinHostPort(host, port)
 }
 
 // readUpgradeResponse reads from conn until the HTTP response header
@@ -171,8 +177,17 @@ func ensureDialPort(addr string, useTLS bool) string {
 // deadline is cleared on return — the long-lived frame relay that follows
 // must not inherit it.
 func readUpgradeResponse(conn net.Conn, timeout time.Duration) ([]byte, error) {
-	_ = conn.SetReadDeadline(time.Now().Add(timeout))
-	defer func() { _ = conn.SetReadDeadline(time.Time{}) }()
+	if err := conn.SetReadDeadline(time.Now().Add(timeout)); err != nil {
+		// Without a deadline the read below could block forever — refuse.
+		return nil, fmt.Errorf("set upgrade read deadline: %w", err)
+	}
+	defer func() {
+		if err := conn.SetReadDeadline(time.Time{}); err != nil {
+			// The relay inherits the stale deadline; its reads will fail
+			// loudly with i/o timeout rather than hang, but flag it here.
+			log.Warn("⚠️  Failed to clear upgrade read deadline: %v", err)
+		}
+	}()
 
 	var buf []byte
 	tmp := make([]byte, 4096)

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -114,8 +114,8 @@ func wsDialPlan(service *common.ServiceConfig, backend string) (addr string, use
 			break
 		}
 	}
-	// Drop any path component — net.Dial wants host:port only.
-	if i := strings.Index(rest, "/"); i >= 0 {
+	// Drop any path, query, or fragment — net.Dial wants host:port only.
+	if i := strings.IndexAny(rest, "/?#"); i >= 0 {
 		rest = rest[:i]
 	}
 	switch scheme {

--- a/internal/agent/websocket_dial_test.go
+++ b/internal/agent/websocket_dial_test.go
@@ -37,6 +37,12 @@ func TestWSDialPlan(t *testing.T) {
 		{"no scheme falls back to service protocol http", "http", "10.0.0.5:8123", "10.0.0.5:8123", false},
 		{"https backend without port gets 443", "http", "https://backend.internal", "backend.internal:443", true},
 		{"http backend without port gets 80", "https", "http://backend.internal", "backend.internal:80", false},
+		{"path component is stripped", "https", "http://10.0.0.5:8123/api/websocket", "10.0.0.5:8123", false},
+		{"path without port is stripped before defaulting", "http", "http://backend.internal/ws", "backend.internal:80", false},
+		{"no scheme with path", "http", "10.0.0.5:8123/ws", "10.0.0.5:8123", false},
+		{"ipv6 with port kept as-is", "http", "http://[::1]:8123", "[::1]:8123", false},
+		{"ipv6 without port gets default", "http", "http://[::1]", "[::1]:80", false},
+		{"ipv6 without port or brackets normalised", "https", "https://[fd00::5]", "[fd00::5]:443", true},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -63,8 +69,7 @@ func TestReadUpgradeResponse_GluedFrame(t *testing.T) {
 		_, _ = server.Write(append([]byte(headers), frame...))
 	}()
 
-	_ = client.SetReadDeadline(time.Now().Add(2 * time.Second))
-	raw, err := readUpgradeResponse(client)
+	raw, err := readUpgradeResponse(client, 2*time.Second)
 	if err != nil {
 		t.Fatalf("readUpgradeResponse: %v", err)
 	}
@@ -91,8 +96,7 @@ func TestReadUpgradeResponse_SplitHeaders(t *testing.T) {
 		_, _ = server.Write([]byte(part2))
 	}()
 
-	_ = client.SetReadDeadline(time.Now().Add(2 * time.Second))
-	raw, err := readUpgradeResponse(client)
+	raw, err := readUpgradeResponse(client, 2*time.Second)
 	if err != nil {
 		t.Fatalf("readUpgradeResponse: %v", err)
 	}
@@ -116,8 +120,29 @@ func TestReadUpgradeResponse_OversizedHeaders(t *testing.T) {
 		}
 	}()
 
-	_ = client.SetReadDeadline(time.Now().Add(2 * time.Second))
-	if _, err := readUpgradeResponse(client); err == nil {
+	if _, err := readUpgradeResponse(client, 2*time.Second); err == nil {
 		t.Fatal("expected error for oversized headers, got nil")
+	}
+}
+
+// TestReadUpgradeResponse_StalledBackend verifies that a backend which sends
+// partial headers and then goes silent cannot pin the goroutine forever — the
+// read deadline aborts the wait.
+func TestReadUpgradeResponse_StalledBackend(t *testing.T) {
+	client, server := net.Pipe()
+	defer client.Close()
+	defer server.Close()
+
+	go func() {
+		_, _ = server.Write([]byte("HTTP/1.1 101 Switching Protocols\r\nUpgrade: web")) // never finishes
+	}()
+
+	start := time.Now()
+	_, err := readUpgradeResponse(client, 150*time.Millisecond)
+	if err == nil {
+		t.Fatal("expected timeout error for stalled backend, got nil")
+	}
+	if elapsed := time.Since(start); elapsed > 2*time.Second {
+		t.Fatalf("stalled read took %v — deadline not applied", elapsed)
 	}
 }

--- a/internal/agent/websocket_dial_test.go
+++ b/internal/agent/websocket_dial_test.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"bytes"
+	"errors"
 	"net"
 	"strings"
 	"testing"
@@ -43,6 +44,8 @@ func TestWSDialPlan(t *testing.T) {
 		{"ipv6 with port kept as-is", "http", "http://[::1]:8123", "[::1]:8123", false},
 		{"ipv6 without port gets default", "http", "http://[::1]", "[::1]:80", false},
 		{"ipv6 without port or brackets normalised", "https", "https://[fd00::5]", "[fd00::5]:443", true},
+		{"stray trailing bracket is not stripped", "http", "http://backend]", "backend]:80", false},
+		{"stray leading bracket is not stripped", "http", "http://[backend", "[backend:80", false},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -144,5 +147,29 @@ func TestReadUpgradeResponse_StalledBackend(t *testing.T) {
 	}
 	if elapsed := time.Since(start); elapsed > 2*time.Second {
 		t.Fatalf("stalled read took %v — deadline not applied", elapsed)
+	}
+}
+
+// deadlineRefusingConn wraps a net.Conn and fails SetReadDeadline, simulating
+// a connection that cannot install a deadline.
+type deadlineRefusingConn struct {
+	net.Conn
+}
+
+func (c deadlineRefusingConn) SetReadDeadline(time.Time) error {
+	return errors.New("deadline not supported")
+}
+
+// TestReadUpgradeResponse_DeadlineSetupFailure verifies that when the read
+// deadline cannot be installed, the function refuses to read (returning the
+// error) instead of proceeding into a potentially unbounded block.
+func TestReadUpgradeResponse_DeadlineSetupFailure(t *testing.T) {
+	client, server := net.Pipe()
+	defer client.Close()
+	defer server.Close()
+
+	_, err := readUpgradeResponse(deadlineRefusingConn{client}, time.Second)
+	if err == nil || !strings.Contains(err.Error(), "deadline") {
+		t.Fatalf("expected deadline setup error, got %v", err)
 	}
 }

--- a/internal/agent/websocket_dial_test.go
+++ b/internal/agent/websocket_dial_test.go
@@ -43,7 +43,11 @@ func TestWSDialPlan(t *testing.T) {
 		{"no scheme with path", "http", "10.0.0.5:8123/ws", "10.0.0.5:8123", false},
 		{"ipv6 with port kept as-is", "http", "http://[::1]:8123", "[::1]:8123", false},
 		{"ipv6 without port gets default", "http", "http://[::1]", "[::1]:80", false},
-		{"ipv6 without port or brackets normalised", "https", "https://[fd00::5]", "[fd00::5]:443", true},
+		{"unbracketed ipv6 gets brackets and default port", "https", "https://fd00::5", "[fd00::5]:443", true},
+		{"bracketed ipv6 without port gets default", "https", "https://[fd00::5]", "[fd00::5]:443", true},
+		{"query suffix is stripped", "https", "http://10.0.0.5:8123?token=x", "10.0.0.5:8123", false},
+		{"fragment suffix is stripped", "https", "http://10.0.0.5:8123#frag", "10.0.0.5:8123", false},
+		{"query without port stripped before defaulting", "http", "backend.internal?x=1", "backend.internal:80", false},
 		{"stray trailing bracket is not stripped", "http", "http://backend]", "backend]:80", false},
 		{"stray leading bracket is not stripped", "http", "http://[backend", "[backend:80", false},
 	}
@@ -144,6 +148,10 @@ func TestReadUpgradeResponse_StalledBackend(t *testing.T) {
 	_, err := readUpgradeResponse(client, 150*time.Millisecond)
 	if err == nil {
 		t.Fatal("expected timeout error for stalled backend, got nil")
+	}
+	var netErr net.Error
+	if !errors.As(err, &netErr) || !netErr.Timeout() {
+		t.Fatalf("error should be a net.Error timeout, got %T: %v", err, err)
 	}
 	if elapsed := time.Since(start); elapsed > 2*time.Second {
 		t.Fatalf("stalled read took %v — deadline not applied", elapsed)


### PR DESCRIPTION
## Summary

- **Path components stripped before dial:** `http://host:8123/api/websocket` previously became `host:8123/api/websocket` and was passed verbatim to net.Dial. wsDialPlan now drops everything after the first `/`.
- **IPv6-safe port defaulting:** the `strings.Contains(addr, ":")` port check misclassified bracketed IPv6 literals (`[::1]` has colons but no port). Replaced with `net.SplitHostPort`/`JoinHostPort`; the TLS ServerName extraction is fixed the same way (`[::1]:443` no longer yields `[`).
- **Bounded upgrade read:** readUpgradeResponse now applies a 30 s read deadline so a backend that sends partial headers and stalls cannot pin the goroutine and TCP connection forever. The deadline is cleared on return so the long-lived frame relay does not inherit it.

## Test plan

- [x] `go test ./... -count=1` — 549 tests pass
- [x] `go test ./internal/agent -count=1 -race` — race detector clean
- [x] `go vet ./internal/agent` — clean
- [x] TestWSDialPlan extended to 14 cases: path stripping (with/without port, scheme-less), IPv6 with/without port, bracket normalisation
- [x] TestReadUpgradeResponse_StalledBackend — partial headers + silence returns a timeout error instead of blocking

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved WebSocket backend connections to better handle URL formats, including paths, missing ports, and IPv6 addresses.
  * Added safer handling for stalled or slow backend upgrade responses, preventing connections from hanging indefinitely.
  * Strengthened TLS host detection for backend WebSocket dialing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Harden WebSocket dial address parsing to handle edge cases (paths, IPv6, missing ports) and add timeout protection to upgrade response reads.

Main changes:
- Refactored `wsDialPlan()` to strip URL components (paths, queries, fragments) and properly handle bracketed IPv6 literals before port defaulting
- Added `dialHostname()` and `ensureDialPort()` helpers with IPv6-safe address parsing using `net.SplitHostPort`
- Implemented timeout parameter in `readUpgradeResponse()` with deadline management to prevent goroutine hangs from stalled backends

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
